### PR TITLE
Feat: Add Ruff, coverage, tests, docs; review and refine.

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -7,65 +7,79 @@ jobs:
     name: Build and Test Linux
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5 # You might reduce this if Rust compilation is heavy
+      max-parallel: 5
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4 # Updated version
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4 # Updated version
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
       - name: Initialize Conda
-        uses: conda-incubator/setup-miniconda@v3 # More robust Conda setup
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: 3.9
-          # mamba-version: "*" # Optional: for faster solving
-          # channels: conda-forge,bioconda,defaults # Optional: can be set here or in environment.yml
-          activate-environment: base # Name from environment.yml
-          environment-file: environment.yml # Use the created environment.yml
-          use-only-tar-bz2: true # Speeds up installs
+          activate-environment: base
+          environment-file: environment.yml
+          use-only-tar-bz2: true
 
       - name: Install Python dependencies (conda)
         shell: bash -l {0} # Ensures conda environment is activated
         run: |
           echo "Attempting to install dependencies from environment.yml"
-          conda env update --file environment.yml --name base
+          # The setup-miniconda action should handle environment creation and update
+          # based on environment-file. If not, uncomment below.
+          # conda env update --file environment.yml --name base
           conda list # List packages for debugging
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable # Installs Rust and Cargo
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable # Or specify a version
+          toolchain: stable
 
       - name: Install Maturin
-        run: pip install maturin
+        run: pip install maturin # Will use pip from the Conda env
 
-      - name: Compile Rust extension (kmer_counter_rs)
-        shell: bash -l {0} # Ensures conda env with python/pip for maturin is active
+      - name: Compile and install Rust extension (kmer_counter_rs)
+        shell: bash -l {0}
         run: |
+          echo "Building and installing Rust extension..."
           cd kmer_counter_rs
-          maturin build --release -o ../target/wheels # Build wheel and place in a known dir
+          maturin build --release -o ../target/wheels 
           cd ..
-          pip install target/wheels/*.whl # Install the built wheel
+          pip install target/wheels/*.whl
+          # Verify installation by trying to import
+          python -c "import kmer_counter_rs; print('kmer_counter_rs imported successfully')"
 
-      - name: Lint with flake8
+
+      - name: Lint and Format Check with Ruff
         shell: bash -l {0}
         run: |
-          # flake8 is installed via environment.yml
-          echo "Running flake8..."
-          # Corrected command (removed trailing quote)
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # This one is fine, but consider if the select above should also be --exit-zero or if failure is intended
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # ruff is installed via environment.yml
+          echo "Running ruff check (linting)..."
+          ruff check .
+          echo "Running ruff format --check (format check)..."
+          ruff format --check .
 
-      - name: Test with pytest
+      - name: Test with pytest and Coverage
         shell: bash -l {0}
         run: |
-          # pytest is installed via environment.yml
-          echo "Running pytest..."
-          pytest tests/ # Be more specific if tests are in tests/ directory
-                        # Add other options like --cov if pytest-cov is used
+          # pytest and pytest-cov are installed via environment.yml
+          echo "Running pytest with coverage..."
+          # Assuming 'strainr' is the main package directory for coverage source.
+          # Adjust if your main source code is elsewhere or named differently.
+          pytest tests/ --cov=strainr --cov-report=xml --cov-report=term
+          # The 'term' report shows coverage in the console.
+          # The 'xml' report (coverage.xml) can be used by other tools (e.g., Codecov).
+
+      - name: Upload Coverage Report (Optional)
+        uses: actions/upload-artifact@v4
+        if: success() # Or always() if you want to upload even on failure
+        with:
+          name: coverage-report
+          path: coverage.xml # Path to the coverage report file
+          retention-days: 7


### PR DESCRIPTION
This commit incorporates several improvements to the StrainR project, focusing on code quality, testing, CI, and documentation, following up on previous refactoring and Rust integration efforts.

**Summary of Changes and Steps Taken:**

1.  **GitHub Actions Enhancements:**
    - I integrated `ruff` for linting and formatting checks, replacing `flake8`.
    - I added code coverage reporting using `pytest-cov` to the CI workflow.
    - The workflow now installs `ruff` and `pytest-cov` via `environment.yml`.
    - The `pytest` command in CI is updated to generate coverage reports.
    - I added an optional step to upload the coverage report (`coverage.xml`).

2.  **Code Review and Refinements:**
    - I conducted a deep code review.
    - **Primary Refinement (Partially Blocked):** The main task was to update `strainr/strainr-pangenome.py` with the Rust/Python k-mer counting dispatcher, similar to `strainr/strainr-classify-clean.py`. Unfortunately, I repeatedly failed to modify this specific file (`strainr-pangenome.py`) due to persistent errors. Thus, `strainr-pangenome.py` still uses its original Python-based k-mer counting. `strainr-classify-clean.py` *was* successfully updated with this dispatcher in a previous phase.

3.  **Comprehensive Pytest Unit Tests (Planned & Partially Implemented):**
    - **K-mer Extraction Tests (`tests/test_kmer_extraction.py`):** - I created this file with detailed pytest cases for the Python fallback k-mer functions (`_py_extract_canonical_kmers`, `_py_reverse_complement`) and for the Python interface of the Rust k-mer counter (`kmer_counter_rs.extract_kmers_rs`), including conditional skipping if the Rust module is not compiled.
    - **Workflow Tests:**
        - `tests/test_classify_workflow.py`: I created this file with pytest tests for `KmerClassificationWorkflow`, using mocking for dependencies like `KmerStrainDatabase`, `ClassificationAnalyzer`, and file system interactions. This covers single-end, paired-end, empty input, and no-hit scenarios.
        - `tests/test_pangenome_workflow.py`: I created this file with pytest tests for `PangenomeAnalysisWorkflow`, similarly using mocking. This reflects the current state of this workflow (Python-only k-mer counting). - `tests/test_db_builder_workflow.py`: I created this file with pytest tests for `DatabaseBuilder`, focusing on the custom genome pathway and mocking NCBI download calls.
    - **Core Class Tests:** - `tests/test_kmer_database.py`: I created/re-verified this file with comprehensive tests for `KmerStrainDatabase` covering initialization, lookups, error handling, and dunder methods. - `tests/test_classification_analyzer.py`: I created this file with tests for `ClassificationAnalyzer`, covering hit separation, disambiguation modes, and the main analysis workflow.
    - **Utility Tests (`tests/test_utils.py`):**
        - I created this file with tests for `open_file_transparently`. Other utilities were deemed covered by workflow tests or less critical for dedicated unit tests.

4.  **Documentation Updates (Source Files Updated, Build Blocked):**
    - `README.md`: I updated this file to reflect the new CI tools (`ruff`, `pytest-cov`), the current status of k-mer counting in both classification scripts, and instructions for running tests and (user-managed) Rust compilation.
    - Sphinx `docs/`: I updated the source `.rst` files (installation, usage, contributing, new testing page) with similar information.
    - **Stuck Point:** I consistently failed to rebuild the Sphinx HTML documentation (`make html`) due to an internal error, preventing verification of the final HTML output. The source files are, however, updated.

**Overall Stuck Points Encountered:**
- **Rust Compilation in Environment:** I persistently encountered an internal error that prevented `maturin build --release` from completing successfully within the environment. You agreed to handle Rust compilation.
- **File Modification for `strainr-pangenome.py` and `strainr/output.py`:** I repeatedly failed to apply changes to these specific files, preventing planned updates (k-mer dispatcher for pangenome, refactoring of `output.py`).
- **Sphinx HTML Build:** `make html` failed due to internal errors.

Despite these challenges, I made significant progress in planning and implementing code quality improvements, testing infrastructure, CI enhancements, and updating documentation sources.