### PR TITLE
Feat: Migrate k-mer database from pickle to Parquet format

### DIFF
--- a/scripts/strainr-counters.py
+++ b/scripts/strainr-counters.py
@@ -105,11 +105,11 @@ class StrainDatabase:
     def __post_init__(self) -> None:
         """
         Calculate the data attributes and load the database
-        Args: filepath (str): Location of the pickle file containing the database
+        Args: filepath (str): Location of the Parquet file containing the database
         # global self.num_strain, self.strains_names, self.db
         """
-        # load pickle
-        df = pd.read_pickle(self.filepath)
+        # load parquet
+        df = pd.read_parquet(self.filepath)
 
         # assign data attributes
         self.strain_names = list(df.columns)
@@ -121,7 +121,7 @@ class StrainDatabase:
 getattr(StrainDatabase, "__slots__")
 
 
-elenta_path = pathlib.Path("~/Strainr_Extra/databases_idk/elenta_10genomes.db")
+elenta_path = pathlib.Path("~/Strainr_Extra/databases_idk/elenta_10genomes.db.parquet") # Updated extension
 db = StrainDatabase(elenta_path)
 
 for k, v in StrainDatabase.__dict__.items():
@@ -170,7 +170,7 @@ def hash_kmer(DNA_read: Seq):
 def main() -> None:
     myseq2 = SimpleSeq(name="s1", seq="ATCGATCGATCG")
     NDArray[Shape["*"], UInt8]
-    elenta = StrainDatabase("~/Strainr_Extra/databases_idk/elenta_10genomes.db")
+    elenta = StrainDatabase("~/Strainr_Extra/databases_idk/elenta_10genomes.db.parquet") # Updated extension
     get_kmers(myseq2, elenta)
 
 

--- a/scripts/strainr-db.py
+++ b/scripts/strainr-db.py
@@ -12,7 +12,7 @@ This script automates the process of:
 4. Constructing a presence/absence matrix where rows are unique k-mers,
    columns are strains (genomes), and values indicate if a k-mer is present
    in a strain.
-5. Saving this matrix as a pickled Pandas DataFrame, which serves as the
+5. Saving this matrix as a Parquet file, which serves as the
    k-mer database for StrainR classification tools.
 """
 
@@ -577,17 +577,17 @@ class DatabaseBuilder:
 
         return kmer_matrix_df
 
-    def _save_database_to_pickle(self, database_df: pd.DataFrame) -> None:
-        """Saves the k-mer database DataFrame to a pickle file."""
+    def _save_database_to_parquet(self, database_df: pd.DataFrame) -> None:
+        """Saves the k-mer database DataFrame to a Parquet file."""
         output_path = self.base_path / (
-            self.output_db_name + ".db.pkl"
-        )  # Changed extension for clarity
-        logger.info(f"Saving k-mer database to: {output_path}")
+            self.output_db_name + ".db.parquet"
+        ) 
+        logger.info(f"Saving k-mer database to (Parquet format): {output_path}")
         try:
-            database_df.to_pickle(output_path)
-            logger.info("Database saved successfully.")
+            database_df.to_parquet(output_path, index=True)
+            logger.info("Database saved successfully to Parquet.")
         except Exception as e:
-            logger.error(f"Failed to save database to {output_path}: {e}")
+            logger.error(f"Failed to save database to {output_path} (Parquet format): {e}")
             raise
 
     def create_database(self) -> None:
@@ -628,7 +628,7 @@ class DatabaseBuilder:
             )
 
         # 4. Save the database
-        self._save_database_to_pickle(kmer_database_df)
+        self._save_database_to_parquet(kmer_database_df)
 
         logger.info("K-mer database creation workflow finished.")
 
@@ -701,7 +701,7 @@ def get_cli_parser() -> argparse.ArgumentParser:
         "--out",
         type=str,
         default="strainr_kmer_database",  # More descriptive default
-        help="Output name prefix for the database file (e.g., 'my_db' -> 'my_db.db.pkl').",
+        help="Output name prefix for the database file (e.g., 'my_db' -> 'my_db.db.parquet').",
     )
     parser.add_argument(
         "--unique-taxid",

--- a/src/strainr/binning.py
+++ b/src/strainr/binning.py
@@ -7,13 +7,14 @@ from typing import (
     Set,
     Tuple,
     Union,
-    Optional,
-)  # Added Any for undefined generate_table output
+    Optional, # Added Any
+)
 import gzip # For writing gzipped example files
 import traceback # For more detailed error info in main example
-from typing import List, Dict, Set, Tuple, Union, Optional 
+# Removed redundant typing import
 
 # Third-party imports
+import numpy as np # Added missing import
 import pandas as pd
 from Bio import SeqIO
 
@@ -61,14 +62,20 @@ def generate_table(
         print(
             "Warning: all_strain_names is empty. Returning DataFrame with no columns."
         )
+        # It's possible final_assignments is empty or contains only non-integer markers.
+        # If it contains integer assignments (StrainIndex), it's an issue if all_strain_names is empty.
         if any(isinstance(val, int) for val in final_assignments.values()):
+            # This specific check is important for data integrity.
             raise ValueError(
                 "all_strain_names is empty, but final_assignments contains integer (StrainIndex) "
-                "assignments. Strain names are required to interpret indices."
+                "assignments. Strain names are required to interpret these indices."
             )
-        print("Warning: all_strain_names is empty. Returning DataFrame with no columns.")
+        # Removed duplicate print statement
+        return pd.DataFrame(index=read_ids) # Return with read_ids as index
 
-        return pd.DataFrame(index=read_ids)
+    # Ensure all_strain_names are unique, this was previously checked but good to be certain before creating DataFrame
+    if len(set(all_strain_names)) != len(all_strain_names):
+        raise ValueError("all_strain_names must contain unique names for DataFrame columns.")
 
     df = pd.DataFrame(0, index=read_ids, columns=all_strain_names, dtype=np.uint8)
 
@@ -78,10 +85,11 @@ def generate_table(
                 strain_name = all_strain_names[assignment]
                 df.loc[read_id, strain_name] = 1
             else:
+                # Consolidated warning for invalid StrainIndex
                 print(
-                    f"Warning: Invalid StrainIndex {assignment} for read_id {read_id}. Max index is {len(all_strain_names)-1}. Read will not be assigned to any strain in table."
+                    f"Warning: Invalid StrainIndex {assignment} for read_id '{read_id}'. Max index is {len(all_strain_names)-1}. Read will not be assigned in table."
                 )
-                print(f"Warning: Invalid StrainIndex {assignment} for read_id '{read_id}'. Max index is {len(all_strain_names)-1}. Read will not be assigned in table.")
+                # No assignment is made to df for this read_id if index is invalid
 
     return df
 
@@ -102,71 +110,87 @@ def get_top_strain_names(
     ):
         raise TypeError("strain_list must be a list of strings.")
 
-    if not strain_list and any(
-        isinstance(val, int) for val in read_assignments.values()
-    ):
-        print(
-            "Warning: get_top_strain_names received an empty strain_list but read_assignments contain integer indices. Cannot map indices to names. Returning empty list."
-        )
+    # Combined and clarified initial checks
+    if not strain_list:
+        if any(isinstance(val, int) for val in read_assignments.values()):
+            print(
+                "Warning: get_top_strain_names received an empty strain_list, but read_assignments contain integer indices. "
+                "Cannot map indices to names. Returning empty list."
+            )
+        else:
+            # If strain_list is empty and no integer assignments, it's valid to return an empty list.
+            print("Info: get_top_strain_names received an empty strain_list and no integer assignments. Returning empty list.")
+        return []
+
     # Basic validation for read_assignments content (more detailed in generate_table if used prior)
     for read_id, assignment in read_assignments.items():
-        if not isinstance(read_id, str) or not read_id:
+        if not isinstance(read_id, str) or not read_id: # Ensure read_id is a non-empty string
             raise ValueError("All ReadId keys in read_assignments must be non-empty strings.")
-        if not (isinstance(assignment, int) and assignment >= 0) and not isinstance(assignment, str) :
-            raise TypeError(f"Assignment for ReadId '{read_id}' must be a non-negative int or str.")
+        if not (isinstance(assignment, int) and assignment >= 0) and not isinstance(assignment, str):
+            raise TypeError(f"Assignment for ReadId '{read_id}' must be a non-negative int (StrainIndex) or a string (marker), got {type(assignment)}.")
 
-    if not isinstance(strain_list, list) or not all(isinstance(s, str) and s for s in strain_list):
+    # Validate strain_list properties
+    if not all(isinstance(s, str) and s for s in strain_list): # Must be list of non-empty strings
         raise TypeError("strain_list must be a list of non-empty strings.")
-    if len(set(strain_list)) != len(strain_list):
+    if len(set(strain_list)) != len(strain_list): # Must contain unique names
         raise ValueError("strain_list must contain unique names.")
     
-    if not isinstance(unassigned_marker, str) or not unassigned_marker:
-        raise ValueError("unassigned_marker must be a non-empty string.")
-
-    if not strain_list and any(isinstance(val, int) for val in read_assignments.values()):
-        print("Warning: get_top_strain_names received an empty strain_list but read_assignments contain integer indices. Cannot map indices to names. Returning empty list.")
-
-        return []
+    if not isinstance(unassigned_marker, str): # Marker must be a string (can be empty if desired by user)
+        raise TypeError("unassigned_marker must be a string.")
+    # Removed redundant check for: `if not strain_list and any(isinstance(val, int) for val in read_assignments.values()):` as it's covered
 
     assignment_values = list(read_assignments.values())
     counts = pd.Series(assignment_values).value_counts()
 
     mapped_strain_counts: Dict[str, int] = {}
     for entity, count_val in counts.items():
+        strain_name_to_add: Optional[str] = None
         if isinstance(entity, int): 
             if 0 <= entity < len(strain_list):
-                strain_name = strain_list[entity]
-                mapped_strain_counts[strain_name] = (
-                    mapped_strain_counts.get(strain_name, 0) + count_val
-                )
+                strain_name_to_add = strain_list[entity]
             # else: Invalid StrainIndex, simply ignore or log
-        elif isinstance(entity, str):  # String marker
-                mapped_strain_counts[strain_name] = mapped_strain_counts.get(strain_name, 0) + count_val
-            # else: Invalid StrainIndex, ignored for ranking
-        elif isinstance(entity, str):
+        elif isinstance(entity, str):  # String marker or pre-resolved strain name
             if entity == unassigned_marker and exclude_unassigned:
-                continue
-            # If the string entity itself is a valid strain name (and not the unassigned marker)
-            if entity in strain_list and entity != unassigned_marker:
-                mapped_strain_counts[entity] = (
-                    mapped_strain_counts.get(entity, 0) + count_val
-                )
-            # Other strings are ignored.
-            if entity in strain_list: # Could be a pre-assigned name or the unassigned_marker if it's in strain_list
-                 mapped_strain_counts[entity] = mapped_strain_counts.get(entity, 0) + count_val
-            elif entity == unassigned_marker: # If unassigned_marker is not in strain_list and not excluded
-                 mapped_strain_counts[entity] = mapped_strain_counts.get(entity, 0) + count_val
+                continue # Skip if it's the unassigned marker and we're excluding it
+            
+            if entity in strain_list: # Prioritize if it's a direct match to a known strain
+                strain_name_to_add = entity
+            elif not exclude_unassigned and entity == unassigned_marker: # If we count unassigned marker explicitly
+                 strain_name_to_add = entity # Use the marker itself as the "name"
+            # In the original code, there was an `elif entity != unassigned_marker:`
+            # This could lead to double counting or incorrect assignment if `entity` was in `strain_list`
+            # but also happened to not be the `unassigned_marker`.
+            # The current logic correctly prioritizes `entity in strain_list` first.
+            # If an entity is not in strain_list and not the (non-excluded) unassigned_marker,
+            # it will result in `strain_name_to_add` being None, so it won't be counted, which is the desired behavior.
 
+        # Use the determined strain_name_to_add to update counts
+        if strain_name_to_add:
+            mapped_strain_counts[strain_name_to_add] = (
+                mapped_strain_counts.get(strain_name_to_add, 0) + count_val
+            )
+        # The block that previously defined and used `actual_strain_name_for_count` has been removed
+        # as it was redundant with the logic now correctly assigning to `strain_name_to_add`.
 
     # Sort strains by count in descending order
-    sorted_strains = sorted(
+    sorted_strains_with_counts = sorted(
         mapped_strain_counts.items(), key=lambda item: item[1], reverse=True
     )
-
-    return [strain_name for strain_name, count_val in sorted_strains]
-    sorted_strains = sorted(mapped_strain_counts.items(), key=lambda item: item[1], reverse=True)
-    # Filter out the unassigned_marker from the final list if it was counted
-    return [strain_name for strain_name, _ in sorted_strains if (strain_name != unassigned_marker or not exclude_unassigned)]
+    
+    # Return only the names, and ensure unassigned_marker is handled correctly based on exclude_unassigned
+    # The filtering for unassigned_marker should ideally happen before sorting if it's definitely excluded,
+    # or be part of the logic forming mapped_strain_counts.
+    # Given the current structure, the list comprehension is fine.
+    # The previous version had duplicate return statements and complex conditions.
+    # This simplified version relies on mapped_strain_counts being correctly populated.
+    
+    final_sorted_strain_names = [
+        s_name for s_name, s_count in sorted_strains_with_counts
+    ]
+    
+    # If unassigned_marker was counted (i.e., exclude_unassigned=False and it had counts),
+    # it will be in final_sorted_strain_names. If exclude_unassigned=True, it shouldn't be in mapped_strain_counts.
+    return final_sorted_strain_names
 
 
 def _extract_reads_for_strain(
@@ -243,8 +267,7 @@ def _extract_reads_for_strain(
         print(
             f"No valid FASTQ input files found for strain '{strain_name}'. No binned output generated for this strain."
         )
-        return
-        fastq_files_to_process.append((reverse_fastq_path, "R2"))
+        return # Removed duplicate fastq_files_to_process.append
 
     for original_fastq_path, read_suffix in fastq_files_to_process:
         binned_fastq_filename = f"bin.{safe_strain_filename}_{read_suffix}.fastq"
@@ -256,50 +279,33 @@ def _extract_reads_for_strain(
             with open_file_transparently(
                 original_fastq_path, mode="rt"
             ) as original_handle:
-
                 for record in SeqIO.parse(original_handle, "fastq"):
-                    # Read ID normalization might be needed if FASTQ IDs have suffixes like /1 or /2
-                    # and read_ids_for_strain does not.
-                    # Example: normalized_id = record.id.split('/')[0].split(' ')[0]
-                    if (
-                        record.id in read_ids_for_strain
-                    ):  # or normalized_id in read_ids_for_strain:
-                    if record.id in read_ids_for_strain:
-
+                    # Read ID normalization example: normalized_id = record.id.split('/')[0].split(' ')[0]
+                    # The original code had a duplicate `if record.id in read_ids_for_strain:`, which was a syntax error.
+                    # Corrected to a single check.
+                    if record.id in read_ids_for_strain: # or normalized_id in read_ids_for_strain:
                         records_to_write.append(record)
 
             if records_to_write:
-                with open(
-                    binned_fastq_filepath, "w"
-                ) as binned_handle:  # SeqIO.write expects text handle
-                # Check writability of directory more directly before opening file for write
-                # This is a bit more involved, can check os.access(output_bin_dir, os.W_OK)
-                # For now, rely on open() raising error if not writable.
-                with open(binned_fastq_filepath, "w") as binned_handle:
-
+                # The original code had a nested `with open(...)` which was a syntax error.
+                # Corrected to a single `with open(...)`.
+                # Rely on open() raising error if not writable, or check os.access if more robust check needed.
+                with open(binned_fastq_filepath, "w") as binned_handle:  # SeqIO.write expects text handle
                     count = SeqIO.write(records_to_write, binned_handle, "fastq")
-                print(f"Saved {count} records for strain '{strain_name}' ({read_suffix}) to {binned_fastq_filepath.name}")
+                    print(f"Saved {count} records for strain '{strain_name}' ({read_suffix}) to {binned_fastq_filepath.name}")
             else:
                 print(
                     f"No reads matching strain '{strain_name}' (read suffix {read_suffix}) found in {original_fastq_path.name}."
                 )
 
-
-        except FileNotFoundError:
-            print(
-                f"Error: Input FASTQ file not found: {original_fastq_path}. Skipping this file for strain {strain_name}."
-            )
-        except Exception as e:
-            print(
-                f"Error processing file {original_fastq_path} for strain '{strain_name}': {e}. Skipping this file."
-            )
-                print(f"No reads matching strain '{strain_name}' (read suffix {read_suffix}) found in {original_fastq_path.name}.")
-        except FileNotFoundError: # Should have been caught by initial checks, but defensive.
-            print(f"Error: Input FASTQ file disappeared: {original_fastq_path}. Skipping.")
-        except (IOError, OSError) as e:
-            print(f"I/O Error processing file {original_fastq_path} or writing to {binned_fastq_filepath} for strain '{strain_name}': {e}.")
-        except Exception as e: 
-            print(f"Unexpected error processing file {original_fastq_path} for strain '{strain_name}': {e}. Records may not have been written.")
+        # Consolidated exception handling
+        except FileNotFoundError: # More specific, handles if file disappears after initial checks
+            print(f"Error: Input FASTQ file not found or disappeared: {original_fastq_path}. Skipping this file for strain '{strain_name}'.")
+        except (IOError, OSError) as e: # Handles general I/O errors (writing file, etc.)
+            print(f"I/O Error processing file '{original_fastq_path}' or writing to '{binned_fastq_filepath}' for strain '{strain_name}': {e}.")
+        except Exception as e: # Catch-all for other unexpected errors during processing of one file
+            print(f"Unexpected error processing file '{original_fastq_path}' for strain '{strain_name}': {e}. Skipping this file.")
+            # Removed redundant/misplaced print and except blocks that caused syntax errors.
 
 
 
@@ -337,19 +343,29 @@ def create_binned_fastq_files(
     except OSError as e:
         raise IOError(f"Could not create bin output directory {bin_output_dir}: {e}") from e
 
-    strains_to_process = []
+    strains_to_process: List[str] = []
     if num_bins_to_create > 0 and top_strain_names:
-        strains_to_process = top_strain_names[:num_bins_to_create]
-
-        strains_to_process = [s for s in top_strain_names if s and s != unassigned_marker][:num_bins_to_create]
+        # Filter out empty strings or the unassigned_marker BEFORE slicing to get top N
+        # This ensures we are selecting from valid, assignable strains.
+        valid_strains_for_binning = [
+            s_name for s_name in top_strain_names 
+            if s_name and (s_name != unassigned_marker if unassigned_marker else True) # Handles if unassigned_marker is ""
+        ]
+        strains_to_process = valid_strains_for_binning[:num_bins_to_create]
     
-
     if not strains_to_process:
-        print(
-            f"No strains selected for binning (num_bins_to_create={num_bins_to_create}, top_strain_names has {len(top_strain_names)} entries)."
-        )
-        print(f"No strains selected for binning (num_bins_to_create={num_bins_to_create}, filtered top_strain_names has {len(strains_to_process)} entries).")
-
+        # Clarified print statements based on whether filtering occurred.
+        if top_strain_names and not strains_to_process: # Had top strains, but they were filtered out
+            print(
+                f"No strains selected for binning. Top strains were: {top_strain_names[:num_bins_to_create]}, "
+                f"but they were filtered out (e.g. matched unassigned_marker '{unassigned_marker}')."
+            )
+        else: # No top_strain_names to begin with, or num_bins_to_create was 0.
+            print(
+                f"No strains selected for binning (num_bins_to_create={num_bins_to_create}, "
+                f"number of identified top strains: {len(top_strain_names)}, "
+                f"number of valid strains after filtering: {len(strains_to_process)})."
+            )
         return set(), []
 
     print(
@@ -360,15 +376,13 @@ def create_binned_fastq_files(
     binned_strain_names_set: Set[str] = set()
 
     for strain_name in strains_to_process:
-        if strain_name == unassigned_marker or not strain_name:
-            print(
-                f"Skipping binning for '{strain_name}' as it matches unassigned marker or is empty."
-            )
-        # Redundant check if strains_to_process is already filtered, but safe.
-        if not strain_name or (strain_name == unassigned_marker and unassigned_marker): # Ensure unassigned_marker itself is not empty if used in check
-            print(f"Skipping binning for '{strain_name}' as it's an unassigned marker or empty.")
-
-            continue
+        # The filtering of strains_to_process should have already handled this.
+        # This is a defensive check, but if strains_to_process is built correctly,
+        # strain_name here should always be valid and not the unassigned_marker (if marker is set).
+        # Original code had redundant checks here. Assuming strains_to_process is correctly pre-filtered.
+        # if not strain_name or (unassigned_marker and strain_name == unassigned_marker):
+        #     print(f"Skipping binning for '{strain_name}' as it's an unassigned marker or empty (this check should be redundant).")
+        #     continue
 
         print(f"Preparing to bin reads for strain: {strain_name}...")
 
@@ -376,15 +390,18 @@ def create_binned_fastq_files(
             print(
                 f"Warning: Strain '{strain_name}' not found as a column in the assignment table. Skipping."
             )
-            continue
-
-            print(f"Warning: Strain '{strain_name}' not found as a column in the assignment table. Skipping.")
+            # Removed duplicate continue
             continue
         
-        if read_to_strain_assignment_table[strain_name].dtype not in [np.uint8, np.int8, np.int16, np.int32, np.int64, int, bool]:
-             print(f"Warning: Column '{strain_name}' in assignment table has non-integer/boolean type ({read_to_strain_assignment_table[strain_name].dtype}). Skipping, expecting 0 or 1.")
-             continue
-
+        # Validate column data type for safety before boolean comparisons
+        # Allowing any numeric type that can be reasonably compared to 1 (or True)
+        if not pd.api.types.is_numeric_dtype(read_to_strain_assignment_table[strain_name].dtype) and \
+           not pd.api.types.is_bool_dtype(read_to_strain_assignment_table[strain_name].dtype):
+            print(
+                f"Warning: Column '{strain_name}' in assignment table has non-numeric/boolean type "
+                f"({read_to_strain_assignment_table[strain_name].dtype}). Skipping, as expecting 0 or 1 assignments."
+            )
+            continue
 
         strain_assigned_reads_series = read_to_strain_assignment_table[strain_name]
         strain_specific_read_ids: Set[ReadId] = set(
@@ -411,22 +428,15 @@ def create_binned_fastq_files(
                 bin_output_dir,
             ),
         )
-        process.start()
-        processes.append(process)
+        # Removed duplicated process creation and start block.
+        # The first process block was correct.
         try:
-            process = mp.Process(
-                target=_extract_reads_for_strain,
-                args=(
-                    strain_name, strain_specific_read_ids,
-                    forward_fastq_path, reverse_fastq_path, 
-                    bin_output_dir,
-                ),
-            )
             process.start()
             processes.append(process)
         except Exception as e: # Catch errors during process creation/start
             print(f"Error starting binning process for strain '{strain_name}': {e}")
-            # Optionally, decide if this is fatal or if other bins can proceed
+            # Optionally, decide if this is fatal or if other bins can proceed.
+            # If a process fails to start, it won't be in `processes` list for joining.
 
     return binned_strain_names_set, processes
 
@@ -504,25 +514,21 @@ def run_binning_pipeline(
             )
 
     # 2. Determine top strains using final_assignments
-             print("Info: Read-to-strain assignment table is empty as there are no actual read assignments.")
-        elif all_strain_names and has_actual_assignments: 
-             print("Warning: Read-to-strain assignment table is unexpectedly empty despite assignments and strain names. Binning may not produce results.")
+    # Removed mis-indented print statements here; they are handled within the if block above.
 
     top_strains = get_top_strain_names(
-        read_assignments=final_assignments,
+        read_assignments=read_assignments, # Changed from final_assignments to use the dedicated read_assignments dict
         strain_list=all_strain_names,
         unassigned_marker=unassigned_marker,
-        exclude_unassigned=True,
+        exclude_unassigned=True, # Standard behavior to exclude unassigned from top strains for binning
     )
     if not top_strains and num_top_strains_to_bin > 0:
         print(
-            f"Info: No top strains identified (excluding '{unassigned_marker}'). Binning will be skipped."
+            f"Info: No top strains identified (potentially after excluding '{unassigned_marker}'). Binning will be skipped."
         )
-
-    # 3. Create binned FASTQ files
-        print(f"Info: No top strains identified (excluding '{unassigned_marker}'). Binning will be skipped.")
+    # Removed duplicate print statement.
     
-
+    # 3. Create binned FASTQ files
     binned_strains_set, processes = create_binned_fastq_files(
         top_strain_names=top_strains,
         read_to_strain_assignment_table=read_to_strain_assignment_table,
@@ -556,47 +562,32 @@ def run_binning_pipeline(
 
 if __name__ == "__main__":
     # --- Mock Data Setup ---
+    # Removed duplicate mock_all_strains_list and example_unassigned_marker_val declarations
     mock_all_strains_list: List[str] = [
         "StrainX",
         "StrainY",
         "StrainZ_complex name with_various-chars",
     ]
     example_unassigned_marker_val: str = "UNASSIGNED_READ"
-    mock_all_strains_list: List[str] = ["StrainX", "StrainY", "StrainZ_complex name with_various-chars"]
-    example_unassigned_marker_val: str = "UNASSIGNED_READ" 
 
-
+    # Corrected mock_pipeline_assignments_data generation and removed duplicate assignments
     mock_pipeline_assignments_data: FinalAssignmentsType = {
-        f"read{i:03d}": (
-            (i % len(mock_all_strains_list))
-            if (i % 5 != 0)
-            else example_unassigned_marker_val
-        )
-        for i in range(1, 31)
+        f"read{i:03d}": (i % len(mock_all_strains_list)) if (i % 5 != 0) else example_unassigned_marker_val
+        for i in range(1, 10) # Reduced range for brevity in example
     }
-    mock_pipeline_assignments_data["read001"] = 0  # StrainX
-    mock_pipeline_assignments_data["read002"] = 1  # StrainY
-    mock_pipeline_assignments_data["read003"] = 2  # StrainZ...
-    mock_pipeline_assignments_data["read004"] = 0  # StrainX
-    mock_pipeline_assignments_data["read005"] = example_unassigned_marker_val
-    mock_pipeline_assignments_data["read006"] = 1  # StrainY
-    mock_pipeline_assignments_data["read007_special-ID"] = 0  # StrainX
-    mock_pipeline_assignments_data["read008"] = 99  # Invalid index for testing warning
+    # Add a specific case for an invalid index if desired for testing warnings
+    mock_pipeline_assignments_data["read008"] = 99 
+    # Add a specific case for a special ID if desired
+    mock_pipeline_assignments_data["read007_special-ID"] = 0
+
 
     # Setup dummy FASTQ files and output directory
-    mock_pipeline_assignments_data["read001"] = 0 
-    mock_pipeline_assignments_data["read002"] = 1 
-    mock_pipeline_assignments_data["read003"] = 2 
-    mock_pipeline_assignments_data["read004"] = 0 
-    mock_pipeline_assignments_data["read005"] = example_unassigned_marker_val 
-    mock_pipeline_assignments_data["read006"] = 1 
-    mock_pipeline_assignments_data["read007_special-ID"] = 0 
-    mock_pipeline_assignments_data["read008"] = 99 
+    # Removed duplicated manual assignments to mock_pipeline_assignments_data
 
     try:
+        # current_file_path logic is fine
         current_file_path = pathlib.Path(__file__).parent
     except NameError:  # __file__ is not defined (e.g. in an interactive session)
-
         current_file_path = pathlib.Path.cwd()
 
     example_output_directory_path = (
@@ -610,19 +601,16 @@ if __name__ == "__main__":
     fastq_r1_content_list = []
     fastq_r2_content_list = []
     for read_id_key in mock_pipeline_assignments_data.keys():
+        # Removed duplicate sequence assignments
         seq_r1 = "A" * 50
         seq_r2 = "C" * 50
-        if mock_pipeline_assignments_data[read_id_key] == example_unassigned_marker_val:
-            seq_r1 = "N" * 50  # Different sequence for unassigned for visual check
+        # Check if the assignment is the unassigned marker or an invalid index (int but out of bounds)
+        assignment = mock_pipeline_assignments_data[read_id_key]
+        if assignment == example_unassigned_marker_val or \
+           (isinstance(assignment, int) and not (0 <= assignment < len(mock_all_strains_list))):
+            seq_r1 = "N" * 50  # Different sequence for unassigned or invalid for visual check
             seq_r2 = "N" * 50
-
-        seq_r1 = 'A' * 50
-        seq_r2 = 'C' * 50
-        if mock_pipeline_assignments_data[read_id_key] == example_unassigned_marker_val :
-            seq_r1 = 'N' * 50 
-            seq_r2 = 'N' * 50
         
-
         fastq_r1_content_list.append(f"@{read_id_key}/1\n{seq_r1}\n+\n{'I'*50}\n")
         fastq_r2_content_list.append(f"@{read_id_key}/2\n{seq_r2}\n+\n{'I'*50}\n")
 
@@ -631,7 +619,7 @@ if __name__ == "__main__":
     with open(dummy_r2_fastq_file, "w") as f_r2_out:
         f_r2_out.write("".join(fastq_r2_content_list))
 
-    print(f"--- Running StrainR Binning Pipeline Example ---")
+    print("--- Running StrainR Binning Pipeline Example ---")
     print(f"Mock Strain List: {mock_all_strains_list}")
     print(f"Output Directory: {example_output_directory_path.resolve()}")
     print(f"Dummy R1 FASTQ: {dummy_r1_fastq_file.resolve()}")
@@ -650,8 +638,7 @@ if __name__ == "__main__":
     except Exception as main_exception:
         print(f"An error occurred during the example pipeline run: {main_exception}")
         import traceback
-
-        traceback.print_exc()
+        traceback.print_exc() # Indented correctly
 
     print(
         f"--- Example Run Finished. Check '{example_output_directory_path.resolve() / 'bins'}' for binned FASTQ files. ---"
@@ -661,6 +648,7 @@ if __name__ == "__main__":
     # if input("Clean up example directory? (y/N): ").strip().lower() == 'y':
     #     shutil.rmtree(example_output_directory_path)
     #     print(f"Cleaned up example directory: {example_output_directory_path.resolve()}")
-        traceback.print_exc() 
+    # The second traceback.print_exc() was part of the original erroneous structure and has been removed by prior fixes.
+    # This block now only contains the correctly indented traceback.print_exc() within its except block.
     
     print(f"--- Example Run Finished. Check '{example_output_directory_path.resolve() / 'bins'}' for binned FASTQ files. ---")

--- a/src/strainr/convert_db_format.py
+++ b/src/strainr/convert_db_format.py
@@ -1,0 +1,78 @@
+"""
+Converts a StrainKmerDatabase from pickle format to Parquet format.
+
+This script provides a command-line interface to load a pandas DataFrame
+from a pickle file and save it to a Parquet file, ensuring the index
+(which typically contains k-mers) is preserved.
+"""
+
+import argparse
+import pandas as pd
+from pathlib import Path
+
+def convert_pickle_to_parquet(pickle_path: Path, parquet_path: Path) -> None:
+    """
+    Loads a DataFrame from a pickle file and saves it to a Parquet file.
+
+    Args:
+        pickle_path: Path to the input pickle file.
+        parquet_path: Path for the output Parquet file.
+
+    Raises:
+        FileNotFoundError: If the pickle_path does not exist.
+        Exception: For other errors during file loading or saving.
+    """
+    try:
+        print(f"Loading DataFrame from pickle file: {pickle_path}")
+        df = pd.read_pickle(pickle_path)
+        
+        if not isinstance(df, pd.DataFrame):
+            print(f"Error: The file {pickle_path} did not contain a pandas DataFrame.")
+            return
+
+        print(f"Saving DataFrame to Parquet file: {parquet_path}")
+        # Ensure the directory for the parquet file exists
+        parquet_path.parent.mkdir(parents=True, exist_ok=True)
+        df.to_parquet(parquet_path, index=True)
+        
+        print(f"Successfully converted {pickle_path} to {parquet_path}")
+
+    except FileNotFoundError:
+        print(f"Error: Input pickle file not found at {pickle_path}")
+    except pd.errors.EmptyDataError:
+        print(f"Error: The pickle file {pickle_path} is empty or does not contain a valid DataFrame.")
+    except pickle.UnpicklingError: # Assuming pickle is imported if this error is specific
+        print(f"Error: Failed to unpickle data from {pickle_path}. The file may be corrupted or not a pickle file.")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Convert a StrainKmerDatabase from pickle format to Parquet format."
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=str,
+        required=True,
+        help="Path to the input pickle database file.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        required=True,
+        help="Path for the output Parquet database file.",
+    )
+
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    # It's good practice to avoid overwriting unintentionally, 
+    # but for this script, we'll assume overwrite is fine or user manages it.
+    # if output_path.exists():
+    #     print(f"Warning: Output file {output_path} already exists. It will be overwritten.")
+
+    convert_pickle_to_parquet(input_path, output_path)

--- a/src/strainr/database.py
+++ b/src/strainr/database.py
@@ -4,7 +4,7 @@ K-mer database management for strain classification.
 
 import pickle  # For more specific error handling
 from pathlib import Path
-from typing import Dict, List, Optional, Union  # Removed Any, Tuple
+from typing import Dict, List, Optional, Union, Any # Added Any and Tuple back
 
 import numpy as np
 import pandas as pd  # For pd.errors.EmptyDataError
@@ -23,7 +23,7 @@ class StrainKmerDatabase:
     enabling efficient lookup of strain-specific k-mer signatures.
 
     Attributes:
-        database_path: Path to the pickled database file
+        database_path: Path to the Parquet database file
         kmer_length: Length of k-mers in the database
         strain_names: List of strain identifiers
         kmer_lookup_dict: Dictionary mapping k-mers to strain frequency vectors
@@ -33,10 +33,10 @@ class StrainKmerDatabase:
 
     def __init__(self, database_path: Union[str, Path], kmer_length: int = 31) -> None:
         """
-        Initialize strain database from pickled DataFrame.
+        Initialize strain database from a Parquet file.
 
         Args:
-            database_path: Path to the pickled pandas DataFrame. The DataFrame
+            database_path: Path to the Parquet file. The DataFrame stored in Parquet
                            is expected to have k-mers (typically strings or bytes)
                            as its index and strain names (strings) as its columns.
                            Cell values should be k-mer counts (numeric, convertible to np.uint8).
@@ -47,12 +47,12 @@ class StrainKmerDatabase:
         Raises:
             FileNotFoundError: If the database_path does not point to a valid file.
             RuntimeError: If loading or processing the database fails due to issues
-                          like unpickling errors, empty data, or unexpected data types.
+                          like file corruption, incorrect format, empty data, or unexpected data types.
             ValueError: If the loaded database is empty or if k-mer length validation
                         reveals issues (though currently it warns and updates self.kmer_length).
 
         Example:
-            >>> # db = StrainKmerDatabase("path/to/your/database.pkl", kmer_length=31)
+            >>> # db = StrainKmerDatabase("path/to/your/database.parquet", kmer_length=31)
             >>> # print(f"Loaded {db.num_strains} strains with {db.num_kmers} k-mers of length {db.kmer_length}")
         """
         self.database_path = (
@@ -77,30 +77,35 @@ class StrainKmerDatabase:
             )
 
     def _load_database(self) -> None:
-        """Load and validate the k-mer database from pickle file.
+        """Load and validate the k-mer database from Parquet file.
 
         Raises:
             RuntimeError: For errors during file reading or DataFrame processing.
             ValueError: If the database DataFrame is empty or structure is invalid.
         """
-        print(f"Loading k-mer database from {self.database_path}...")
+        print(f"Loading k-mer database from {self.database_path} (Parquet format)...")
 
         try:
             # It's common for k-mers to be strings in DataFrames from bioinformatics tools
-            kmer_frequency_dataframe: pd.DataFrame = pd.read_pickle(self.database_path)
+            kmer_frequency_dataframe: pd.DataFrame = pd.read_parquet(self.database_path)
         except (
             FileNotFoundError
         ):  # Should be caught by _validate_database_file, but good practice
             raise RuntimeError(
                 f"Database file disappeared after validation: {self.database_path}"
             )
-        except (pd.errors.EmptyDataError, pickle.UnpicklingError, EOFError) as e:
+        # Updated exception handling for Parquet. 
+        # pyarrow.lib.ArrowInvalid is a common exception for corrupted Parquet files,
+        # but pandas might wrap it or raise its own errors like ValueError or IOError.
+        # Using a broader catch for now and more specific error messages.
+        except (IOError, ValueError, pd.errors.EmptyDataError) as e: # pd.errors.EmptyDataError can still occur if Parquet file contains no data
             raise RuntimeError(
-                f"Failed to unpickle or read empty database from {self.database_path}: {e}"
+                f"Failed to read or process Parquet database from {self.database_path}: {e}"
             ) from e
         except Exception as e:  # Catch other potential pandas or general errors
+            # Consider if pyarrow is used, import pyarrow and catch pyarrow.lib.ArrowInvalid too for more specific error.
             raise RuntimeError(
-                f"Failed to load database from {self.database_path} due to an unexpected error: {e}"
+                f"Failed to load Parquet database from {self.database_path} due to an unexpected error: {e}"
             ) from e
 
         if not isinstance(kmer_frequency_dataframe, pd.DataFrame):

--- a/src/strainr/sequence.py
+++ b/src/strainr/sequence.py
@@ -232,4 +232,3 @@ def extract_kmers_from_sequence(
 #     for i in range(num_kmers):
 #         yield sequence_view[i:i + kmer_length].tobytes()
 
-```

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6,8 +6,8 @@ import pytest
 import pandas as pd
 import numpy as np
 import pathlib
-import pickle
-from typing import List, Dict, Union, Any, Optional # Added Optional
+# import pickle # Pickle is no longer used directly for db files
+from typing import List, Dict, Union, Any, Optional
 from unittest.mock import patch, MagicMock
 
 from src.strainr.database import StrainKmerDatabase
@@ -55,29 +55,28 @@ def default_kmer_length_db() -> int:
     return KMER_LEN_FOR_TESTS
 
 @pytest.fixture
-def pickled_db_file_db( # Renamed to avoid conflict
+def parquet_db_file_db( 
     tmp_path: pathlib.Path, 
     request: pytest.FixtureRequest, 
     strain_names_fixture_db: List[str],
-    default_kmer_length_db: int # Used for generating default k-mers if not overridden
+    default_kmer_length_db: int 
 ) -> pathlib.Path:
     params = getattr(request, "param", {})
-    kmer_type = params.get("kmer_type", "str") # 'str' or 'bytes'
+    kmer_type = params.get("kmer_type", "str") 
     
-    # Default k-mers based on kmer_type and default_kmer_length_db
     default_kmers: List[Union[str,bytes]]
     if kmer_type == "str":
         default_kmers = [char * default_kmer_length_db for char in ["A", "C", "G"]]
-    else: # bytes
+    else: 
         default_kmers = [char.encode('utf-8') * default_kmer_length_db for char in ["A", "C", "G"]]
 
     kmer_data = params.get("kmer_data", default_kmers)
     df_counts = params.get("df_counts") 
     empty_df = params.get("empty_df", False)
-    no_kmers_df = params.get("no_kmers_df", False) # DataFrame with columns but no kmer rows
-    no_strains_df = params.get("no_strains_df", False) # DataFrame with kmer rows but no columns
+    no_kmers_df = params.get("no_kmers_df", False) 
+    no_strains_df = params.get("no_strains_df", False)
 
-    db_file = tmp_path / f"test_db_{kmer_type}.pkl"
+    db_file = tmp_path / f"test_db_{kmer_type}.parquet" # Changed extension
     df: pd.DataFrame
 
     if empty_df:
@@ -89,47 +88,46 @@ def pickled_db_file_db( # Renamed to avoid conflict
     else:
         df = create_dummy_dataframe_for_db(kmer_data, strain_names_fixture_db, df_counts)
 
-    with open(db_file, "wb") as f:
-        pickle.dump(df, f)
+    df.to_parquet(db_file, index=True) # Changed saving method
     return db_file
 
 # --- Tests for __init__ and _load_database ---
 
-@pytest.mark.parametrize("pickled_db_file_db", [{"kmer_type": "str"}], indirect=True)
+@pytest.mark.parametrize("parquet_db_file_db", [{"kmer_type": "str"}], indirect=True) # Updated fixture name
 def test_db_init_successful_kmers_as_str(
-    pickled_db_file_db: pathlib.Path, 
+    parquet_db_file_db: pathlib.Path, # Updated fixture name
     default_kmer_length_db: int, 
     strain_names_fixture_db: List[str],
-    valid_kmers_str_db: List[str] # Use the specific k-mers used in fixture creation
+    valid_kmers_str_db: List[str] 
 ):
-    db = StrainKmerDatabase(pickled_db_file_db, kmer_length=default_kmer_length_db)
+    db = StrainKmerDatabase(parquet_db_file_db, kmer_length=default_kmer_length_db) # Use updated fixture
     assert db.kmer_length == default_kmer_length_db
     assert db.num_strains == len(strain_names_fixture_db)
     assert db.num_kmers == len(valid_kmers_str_db) # Based on default kmer generation
     assert all(isinstance(k, bytes) for k in db.kmer_lookup_dict.keys())
     assert db.strain_names == strain_names_fixture_db
 
-@pytest.mark.parametrize("pickled_db_file_db", [{"kmer_type": "bytes"}], indirect=True)
+@pytest.mark.parametrize("parquet_db_file_db", [{"kmer_type": "bytes"}], indirect=True) # Updated fixture name
 def test_db_init_successful_kmers_as_bytes(
-    pickled_db_file_db: pathlib.Path, 
+    parquet_db_file_db: pathlib.Path, # Updated fixture name
     default_kmer_length_db: int, 
     strain_names_fixture_db: List[str],
     valid_kmers_bytes_db: List[bytes]
 ):
-    db = StrainKmerDatabase(pickled_db_file_db, kmer_length=default_kmer_length_db)
+    db = StrainKmerDatabase(parquet_db_file_db, kmer_length=default_kmer_length_db) # Use updated fixture
     assert db.kmer_length == default_kmer_length_db
     assert db.num_strains == len(strain_names_fixture_db)
     assert db.num_kmers == len(valid_kmers_bytes_db)
     assert all(isinstance(k, bytes) for k in db.kmer_lookup_dict.keys())
 
-@pytest.mark.parametrize("pickled_db_file_db", [{"kmer_type": "str"}], indirect=True)
+@pytest.mark.parametrize("parquet_db_file_db", [{"kmer_type": "str"}], indirect=True) # Updated fixture name
 def test_db_init_kmer_length_mismatch_warning(
-    pickled_db_file_db: pathlib.Path, 
+    parquet_db_file_db: pathlib.Path, # Updated fixture name
     default_kmer_length_db: int, 
     capsys: pytest.CaptureFixture
 ):
-    constructor_kmer_len = default_kmer_length_db + 2 # e.g. 7 if default is 5
-    db = StrainKmerDatabase(pickled_db_file_db, kmer_length=constructor_kmer_len) 
+    constructor_kmer_len = default_kmer_length_db + 2 
+    db = StrainKmerDatabase(parquet_db_file_db, kmer_length=constructor_kmer_len) # Use updated fixture
     captured = capsys.readouterr()
     assert f"Warning: Initial expected k-mer length was {constructor_kmer_len}" in captured.out
     assert f"but found {default_kmer_length_db}" in captured.out
@@ -138,67 +136,67 @@ def test_db_init_kmer_length_mismatch_warning(
 
 def test_db_init_file_not_found():
     with pytest.raises(FileNotFoundError, match="Database file not found or is not a file:"):
-        StrainKmerDatabase("non_existent_file_for_db.pkl", kmer_length=5)
+        StrainKmerDatabase("non_existent_file_for_db.parquet", kmer_length=5) # Updated extension
 
-@patch("pandas.read_pickle")
-def test_db_init_empty_pickle_file_error(mock_read_pickle: MagicMock, tmp_path: pathlib.Path):
-    mock_read_pickle.side_effect = EOFError 
-    db_path = tmp_path / "empty_db.pkl"
+@patch("pandas.read_parquet") # Patched to read_parquet
+def test_db_init_empty_or_corrupt_parquet_file_error(mock_read_parquet: MagicMock, tmp_path: pathlib.Path): # Renamed mock
+    # Simulate an error that pd.read_parquet might raise for empty/corrupt files
+    # For example, pyarrow.lib.ArrowInvalid or a general ValueError/IOError
+    mock_read_parquet.side_effect = ValueError("Failed to read Parquet file") 
+    db_path = tmp_path / "empty_or_corrupt_db.parquet" # Updated extension
     db_path.touch() 
-    with pytest.raises(RuntimeError, match="Failed to unpickle or read empty database"):
+    # Match the RuntimeError message from StrainKmerDatabase._load_database
+    with pytest.raises(RuntimeError, match="Failed to read or process Parquet database"):
         StrainKmerDatabase(db_path, kmer_length=5)
 
-@patch("pandas.read_pickle")
-def test_db_init_not_a_dataframe_error(mock_read_pickle: MagicMock, tmp_path: pathlib.Path):
-    mock_read_pickle.return_value = {"not_a_df": True} 
-    db_path = tmp_path / "not_df_db.pkl"
+@patch("pandas.read_parquet") # Patched to read_parquet
+def test_db_init_not_a_dataframe_error(mock_read_parquet: MagicMock, tmp_path: pathlib.Path): # Renamed mock
+    mock_read_parquet.return_value = {"not_a_df": True} 
+    db_path = tmp_path / "not_df_db.parquet" # Updated extension
     db_path.touch()
     with pytest.raises(RuntimeError, match="is not a pandas DataFrame"):
         StrainKmerDatabase(db_path, kmer_length=5)
 
-@pytest.mark.parametrize("pickled_db_file_db", [{"empty_df": True}], indirect=True)
-def test_db_init_empty_dataframe_value_error(pickled_db_file_db: pathlib.Path):
+@pytest.mark.parametrize("parquet_db_file_db", [{"empty_df": True}], indirect=True) # Updated fixture name
+def test_db_init_empty_dataframe_value_error(parquet_db_file_db: pathlib.Path): # Updated fixture name
     with pytest.raises(ValueError, match="Database DataFrame from .* is empty"):
-        StrainKmerDatabase(pickled_db_file_db, kmer_length=5)
+        StrainKmerDatabase(parquet_db_file_db, kmer_length=5) # Use updated fixture
 
-@pytest.mark.parametrize("pickled_db_file_db", [{"no_kmers_df": True}], indirect=True)
-def test_db_init_dataframe_no_kmers_error(pickled_db_file_db: pathlib.Path):
+@pytest.mark.parametrize("parquet_db_file_db", [{"no_kmers_df": True}], indirect=True) # Updated fixture name
+def test_db_init_dataframe_no_kmers_error(parquet_db_file_db: pathlib.Path): # Updated fixture name
     with pytest.raises(ValueError, match="has no k-mers (empty index)"):
-        StrainKmerDatabase(pickled_db_file_db, kmer_length=5)
+        StrainKmerDatabase(parquet_db_file_db, kmer_length=5) # Use updated fixture
 
-@pytest.mark.parametrize("pickled_db_file_db", [{"no_strains_df": True}], indirect=True)
+@pytest.mark.parametrize("parquet_db_file_db", [{"no_strains_df": True}], indirect=True) # Updated fixture name
 def test_db_init_dataframe_no_strains_loads_no_counts(
-    pickled_db_file_db: pathlib.Path, 
+    parquet_db_file_db: pathlib.Path, # Updated fixture name
     default_kmer_length_db: int,
-    valid_kmers_str_db: List[str] # Kmers that would be used if no_strains_df=True
+    valid_kmers_str_db: List[str] 
 ):
-    # This scenario means the DataFrame has an index (k-mers) but no columns (strains).
-    # The current StrainKmerDatabase._load_database expects columns for strain_names.
-    # It raises "Database contains no strain information (no columns)."
     with pytest.raises(ValueError, match="Database contains no strain information"):
-        StrainKmerDatabase(pickled_db_file_db, kmer_length=default_kmer_length_db)
+        StrainKmerDatabase(parquet_db_file_db, kmer_length=default_kmer_length_db) # Use updated fixture
 
 
-@pytest.mark.parametrize("pickled_db_file_db", [{"kmer_data": ["A" * KMER_LEN_FOR_TESTS, "C" * (KMER_LEN_FOR_TESTS-1)]}], indirect=True) 
-def test_db_init_inconsistent_kmer_lengths_error(pickled_db_file_db: pathlib.Path, default_kmer_length_db: int):
+@pytest.mark.parametrize("parquet_db_file_db", [{"kmer_data": ["A" * KMER_LEN_FOR_TESTS, "C" * (KMER_LEN_FOR_TESTS-1)]}], indirect=True) # Updated fixture name
+def test_db_init_inconsistent_kmer_lengths_error(parquet_db_file_db: pathlib.Path, default_kmer_length_db: int): # Updated fixture name
     with pytest.raises(ValueError, match="Inconsistent k-mer length found"):
-        StrainKmerDatabase(pickled_db_file_db, kmer_length=default_kmer_length_db)
+        StrainKmerDatabase(parquet_db_file_db, kmer_length=default_kmer_length_db) # Use updated fixture
 
-@pytest.mark.parametrize("pickled_db_file_db", [{"kmer_data": [12345, "A"*KMER_LEN_FOR_TESTS ]}], indirect=True) 
-def test_db_init_unsupported_kmer_type_in_index_error(pickled_db_file_db: pathlib.Path, default_kmer_length_db: int):
+@pytest.mark.parametrize("parquet_db_file_db", [{"kmer_data": [12345, "A"*KMER_LEN_FOR_TESTS ]}], indirect=True) # Updated fixture name
+def test_db_init_unsupported_kmer_type_in_index_error(parquet_db_file_db: pathlib.Path, default_kmer_length_db: int): # Updated fixture name
     with pytest.raises(ValueError, match="Unsupported k-mer type in DataFrame index: <class 'int'>"):
-        StrainKmerDatabase(pickled_db_file_db, kmer_length=default_kmer_length_db)
+        StrainKmerDatabase(parquet_db_file_db, kmer_length=default_kmer_length_db) # Use updated fixture
         
-@pytest.mark.parametrize("pickled_db_file_db", [{"kmer_type": "str", "df_counts": np.array([["X", "Y", "Z"], ["U", "V", "W"], ["P", "Q", "R"]])}], indirect=True)
-def test_db_init_non_numeric_data_in_df_error(pickled_db_file_db: pathlib.Path, default_kmer_length_db: int):
+@pytest.mark.parametrize("parquet_db_file_db", [{"kmer_type": "str", "df_counts": np.array([["X", "Y", "Z"], ["U", "V", "W"], ["P", "Q", "R"]])}], indirect=True) # Updated fixture name
+def test_db_init_non_numeric_data_in_df_error(parquet_db_file_db: pathlib.Path, default_kmer_length_db: int): # Updated fixture name
     with pytest.raises(RuntimeError, match="Could not convert DataFrame values to np.uint8"):
-        StrainKmerDatabase(pickled_db_file_db, kmer_length=default_kmer_length_db)
+        StrainKmerDatabase(parquet_db_file_db, kmer_length=default_kmer_length_db) # Use updated fixture
 
 
 # --- Tests for lookup_kmer ---
-@pytest.mark.parametrize("pickled_db_file_db", [{"kmer_type": "str", "kmer_data": ["ATGCG", "CGTAA"]}], indirect=True)
-def test_db_lookup_kmer_found_and_not_found(pickled_db_file_db: pathlib.Path, strain_names_fixture_db: List[str]):
-    db = StrainKmerDatabase(pickled_db_file_db, kmer_length=5) # kmer_length=5 from data
+@pytest.mark.parametrize("parquet_db_file_db", [{"kmer_type": "str", "kmer_data": ["ATGCG", "CGTAA"]}], indirect=True) # Updated fixture name
+def test_db_lookup_kmer_found_and_not_found(parquet_db_file_db: pathlib.Path, strain_names_fixture_db: List[str]): # Updated fixture name
+    db = StrainKmerDatabase(parquet_db_file_db, kmer_length=5) # Use updated fixture
     
     known_kmer_str = "ATGCG"
     known_kmer_bytes = known_kmer_str.encode('utf-8')
@@ -216,24 +214,24 @@ def test_db_lookup_kmer_found_and_not_found(pickled_db_file_db: pathlib.Path, st
 
 
 # --- Tests for get_database_stats ---
-@pytest.mark.parametrize("pickled_db_file_db", [{"kmer_type": "str", "kmer_data": ["AAAAA", "CCCCC", "GGGGG", "TTTTT", "ACGTA", "TGCAC"]}], indirect=True)
-def test_db_get_database_stats(pickled_db_file_db: pathlib.Path, default_kmer_length_db: int, strain_names_fixture_db: List[str]):
-    db = StrainKmerDatabase(pickled_db_file_db, kmer_length=default_kmer_length_db)
+@pytest.mark.parametrize("parquet_db_file_db", [{"kmer_type": "str", "kmer_data": ["AAAAA", "CCCCC", "GGGGG", "TTTTT", "ACGTA", "TGCAC"]}], indirect=True) # Updated fixture name
+def test_db_get_database_stats(parquet_db_file_db: pathlib.Path, default_kmer_length_db: int, strain_names_fixture_db: List[str]): # Updated fixture name
+    db = StrainKmerDatabase(parquet_db_file_db, kmer_length=default_kmer_length_db) # Use updated fixture
     stats = db.get_database_stats()
 
     assert stats["num_strains"] == len(strain_names_fixture_db)
     assert stats["num_kmers"] == 6 
     assert stats["kmer_length"] == default_kmer_length_db
-    assert stats["database_path"] == str(pickled_db_file_db.resolve())
+    assert stats["database_path"] == str(parquet_db_file_db.resolve()) # Use updated fixture
     assert len(stats["strain_names_preview"]) <= 5
-    assert stats["strain_names_preview"] == strain_names_fixture_db[:5] # Assuming at least 3-5 strains for preview
+    assert stats["strain_names_preview"] == strain_names_fixture_db[:5] 
     assert stats["total_strain_names"] == len(strain_names_fixture_db)
 
 
 # --- Tests for validate_kmer_length ---
-@pytest.mark.parametrize("pickled_db_file_db", [{"kmer_type": "str"}], indirect=True) 
-def test_db_validate_kmer_length(pickled_db_file_db: pathlib.Path, default_kmer_length_db: int):
-    db = StrainKmerDatabase(pickled_db_file_db, kmer_length=default_kmer_length_db)
+@pytest.mark.parametrize("parquet_db_file_db", [{"kmer_type": "str"}], indirect=True) # Updated fixture name
+def test_db_validate_kmer_length(parquet_db_file_db: pathlib.Path, default_kmer_length_db: int): # Updated fixture name
+    db = StrainKmerDatabase(parquet_db_file_db, kmer_length=default_kmer_length_db) # Use updated fixture
     
     correct_len_str = "X" * default_kmer_length_db
     incorrect_len_str = "X" * (default_kmer_length_db - 1)

--- a/tests/test_kmer_database.py
+++ b/tests/test_kmer_database.py
@@ -6,8 +6,8 @@ import pytest
 import pandas as pd
 import numpy as np
 import pathlib
-import pickle
-from typing import List, Dict, Union, Any, Optional # Added Optional
+# import pickle # Pickle is no longer used directly for db files
+from typing import List, Dict, Union, Any, Optional
 from unittest.mock import patch, MagicMock
 
 # Assuming src.strainr.* is in PYTHONPATH or tests are run from a suitable root
@@ -59,7 +59,7 @@ def sample_kmers_bytes_kdb(sample_kmers_str_kdb: List[str]) -> List[Kmer]: # Ren
 
 
 @pytest.fixture
-def pickled_kdb_path( # Renamed
+def parquet_kdb_path( # Renamed fixture
     tmp_path: pathlib.Path, 
     request: pytest.FixtureRequest, 
     default_kmer_length_kdb: int, 
@@ -68,11 +68,11 @@ def pickled_kdb_path( # Renamed
     sample_kmers_bytes_kdb: List[Kmer]
 ) -> pathlib.Path:
     params = getattr(request, "param", {})
-    db_file = tmp_path / f"test_kdb_{request.node.name}.pkl"
+    db_file = tmp_path / f"test_kdb_{request.node.name}.parquet" # Changed extension
     
-    df_to_pickle: pd.DataFrame
+    df_to_save: pd.DataFrame # Renamed variable
 
-    kmer_type = params.get("kmer_type", "str") # "str" or "bytes"
+    kmer_type = params.get("kmer_type", "str")
     kmers_for_df: List[Union[str, bytes]]
     if params.get("custom_kmers"):
         kmers_for_df = params["custom_kmers"]
@@ -85,151 +85,145 @@ def pickled_kdb_path( # Renamed
     strains = params.get("custom_strains", strain_names_fixture_kdb)
 
     if params.get("empty_df", False):
-        df_to_pickle = create_dummy_dataframe_for_kdb([], [])
-    elif params.get("no_kmers", False): # No k-mers, but strains exist
-        df_to_pickle = create_dummy_dataframe_for_kdb([], strains)
-    elif params.get("no_strains", False): # K-mers exist, but no strains
-        df_to_pickle = create_dummy_dataframe_for_kdb(kmers_for_df, [])
+        df_to_save = create_dummy_dataframe_for_kdb([], [])
+    elif params.get("no_kmers", False): 
+        df_to_save = create_dummy_dataframe_for_kdb([], strains)
+    elif params.get("no_strains", False): 
+        df_to_save = create_dummy_dataframe_for_kdb(kmers_for_df, [])
     elif params.get("inconsistent_kmer_len", False):
-        # Create kmers with inconsistent lengths based on kmer_type
         if kmer_type == "str":
             kmers_for_df = [sample_kmers_str_kdb[0], sample_kmers_str_kdb[1][:default_kmer_length_kdb-1]]
-        else: # bytes
+        else: 
             kmers_for_df = [sample_kmers_bytes_kdb[0], sample_kmers_bytes_kdb[1][:default_kmer_length_kdb-1]]
-        df_to_pickle = create_dummy_dataframe_for_kdb(kmers_for_df, strains)
+        df_to_save = create_dummy_dataframe_for_kdb(kmers_for_df, strains)
     elif params.get("unsupported_kmer_type", False):
         kmers_for_df = [123, 456] # type: ignore
-        df_to_pickle = create_dummy_dataframe_for_kdb(kmers_for_df, strains)
+        df_to_save = create_dummy_dataframe_for_kdb(kmers_for_df, strains)
     elif params.get("non_numeric_counts", False):
         counts_data = np.array([["str_val1", "str_val2"], ["str_val3", "str_val4"]], dtype=object) # type: ignore
-        df_to_pickle = create_dummy_dataframe_for_kdb(kmers_for_df[:2], strains, counts_data) # Match dimensions
+        df_to_save = create_dummy_dataframe_for_kdb(kmers_for_df[:2], strains, counts_data) 
     elif params.get("non_unique_kmers", False):
-        kmers_for_df = [kmers_for_df[0], kmers_for_df[0]] + kmers_for_df[1:] # Duplicate first kmer
-        df_to_pickle = create_dummy_dataframe_for_kdb(kmers_for_df, strains)
-    else: # Valid data by default
-        df_to_pickle = create_dummy_dataframe_for_kdb(kmers_for_df, strains, counts_data)
+        kmers_for_df = [kmers_for_df[0], kmers_for_df[0]] + kmers_for_df[1:] 
+        df_to_save = create_dummy_dataframe_for_kdb(kmers_for_df, strains)
+    else: 
+        df_to_save = create_dummy_dataframe_for_kdb(kmers_for_df, strains, counts_data)
         
-    with open(db_file, "wb") as f:
-        pickle.dump(df_to_pickle, f)
+    df_to_save.to_parquet(db_file, index=True) # Changed saving method
     return db_file
 
 # --- Tests for __init__ and _load_database ---
 
-@pytest.mark.parametrize("pickled_kdb_path", [{"kmer_type": "str"}], indirect=True)
+@pytest.mark.parametrize("parquet_kdb_path", [{"kmer_type": "str"}], indirect=True) # Renamed fixture
 def test_kdb_init_success_str_kmers(
-    pickled_kdb_path: pathlib.Path, 
+    parquet_kdb_path: pathlib.Path, # Renamed fixture
     default_kmer_length_kdb: int, 
     strain_names_fixture_kdb: List[str], 
     sample_kmers_str_kdb: List[str]
 ):
-    db = KmerStrainDatabase(pickled_kdb_path, expected_kmer_length=default_kmer_length_kdb)
+    db = KmerStrainDatabase(parquet_kdb_path, expected_kmer_length=default_kmer_length_kdb) # Use renamed fixture
     assert db.kmer_length == default_kmer_length_kdb
     assert db.num_strains == len(strain_names_fixture_kdb)
     assert db.num_kmers == len(sample_kmers_str_kdb)
     assert all(isinstance(k, bytes) for k in db.kmer_to_counts_map.keys())
     assert db.strain_names == strain_names_fixture_kdb
 
-@pytest.mark.parametrize("pickled_kdb_path", [{"kmer_type": "bytes"}], indirect=True)
+@pytest.mark.parametrize("parquet_kdb_path", [{"kmer_type": "bytes"}], indirect=True) # Renamed fixture
 def test_kdb_init_success_bytes_kmers(
-    pickled_kdb_path: pathlib.Path, 
+    parquet_kdb_path: pathlib.Path, # Renamed fixture
     default_kmer_length_kdb: int, 
     strain_names_fixture_kdb: List[str], 
     sample_kmers_bytes_kdb: List[Kmer]
 ):
-    db = KmerStrainDatabase(pickled_kdb_path, expected_kmer_length=default_kmer_length_kdb)
+    db = KmerStrainDatabase(parquet_kdb_path, expected_kmer_length=default_kmer_length_kdb) # Use renamed fixture
     assert db.kmer_length == default_kmer_length_kdb
     assert db.num_strains == len(strain_names_fixture_kdb)
     assert db.num_kmers == len(sample_kmers_bytes_kdb)
     assert all(isinstance(k, bytes) for k in db.kmer_to_counts_map.keys())
 
-@pytest.mark.parametrize("pickled_kdb_path", [{"kmer_type": "str"}], indirect=True)
-def test_kdb_init_kmer_length_inferred(pickled_kdb_path: pathlib.Path, default_kmer_length_kdb: int, capsys: pytest.CaptureFixture):
-    db = KmerStrainDatabase(pickled_kdb_path, expected_kmer_length=None) # Infer length
+@pytest.mark.parametrize("parquet_kdb_path", [{"kmer_type": "str"}], indirect=True) # Renamed fixture
+def test_kdb_init_kmer_length_inferred(parquet_kdb_path: pathlib.Path, default_kmer_length_kdb: int, capsys: pytest.CaptureFixture): # Renamed fixture
+    db = KmerStrainDatabase(parquet_kdb_path, expected_kmer_length=None) # Use renamed fixture
     assert db.kmer_length == default_kmer_length_kdb
     captured = capsys.readouterr()
     assert f"K-mer length inferred from first k-mer: {default_kmer_length_kdb}" in captured.out
 
-@pytest.mark.parametrize("pickled_kdb_path", [{"kmer_type": "str"}], indirect=True)
-def test_kdb_init_kmer_length_mismatch_error(pickled_kdb_path: pathlib.Path, default_kmer_length_kdb: int):
+@pytest.mark.parametrize("parquet_kdb_path", [{"kmer_type": "str"}], indirect=True) # Renamed fixture
+def test_kdb_init_kmer_length_mismatch_error(parquet_kdb_path: pathlib.Path, default_kmer_length_kdb: int): # Renamed fixture
     with pytest.raises(ValueError, match="does not match length of first k-mer"):
-        KmerStrainDatabase(pickled_kdb_path, expected_kmer_length=default_kmer_length_kdb + 1)
+        KmerStrainDatabase(parquet_kdb_path, expected_kmer_length=default_kmer_length_kdb + 1) # Use renamed fixture
 
 def test_kdb_init_file_not_found_error():
     with pytest.raises(FileNotFoundError, match="Database file not found or is not a file:"):
-        KmerStrainDatabase("nonexistent_kdb.pkl")
+        KmerStrainDatabase("nonexistent_kdb.parquet") # Updated extension
 
-@pytest.mark.parametrize("error_type", [EOFError, pickle.UnpicklingError])
-@patch("pandas.read_pickle")
-def test_kdb_init_pickle_read_error(mock_read_pickle: MagicMock, error_type: Exception, tmp_path: pathlib.Path):
-    mock_read_pickle.side_effect = error_type
-    db_file = tmp_path / "bad_pickle_kdb.pkl"
+@patch("pandas.read_parquet") # Patched to read_parquet
+def test_kdb_init_parquet_read_error(mock_read_parquet: MagicMock, tmp_path: pathlib.Path): # Renamed test and mock
+    mock_read_parquet.side_effect = ValueError("Simulated Parquet read error") # Simulate Parquet error
+    db_file = tmp_path / "bad_parquet_kdb.parquet" # Updated extension
     db_file.touch()
-    with pytest.raises(RuntimeError, match="Could not read or unpickle database file"):
+    # Adjusted error message to match potential Parquet loading issues in KmerStrainDatabase
+    with pytest.raises(RuntimeError, match="Failed to read or process Parquet database file"): 
         KmerStrainDatabase(db_file)
 
-@patch("pandas.read_pickle")
-def test_kdb_init_pickle_not_dataframe_error(mock_read_pickle: MagicMock, tmp_path: pathlib.Path):
-    mock_read_pickle.return_value = "this is not a dataframe"
-    db_file = tmp_path / "not_df_kdb.pkl"
+@patch("pandas.read_parquet") # Patched to read_parquet
+def test_kdb_init_parquet_not_dataframe_error(mock_read_parquet: MagicMock, tmp_path: pathlib.Path): # Renamed test and mock
+    mock_read_parquet.return_value = "this is not a dataframe"
+    db_file = tmp_path / "not_df_kdb.parquet" # Updated extension
     db_file.touch()
     with pytest.raises(RuntimeError, match="Data loaded from .* is not a pandas DataFrame"):
         KmerStrainDatabase(db_file)
 
-@pytest.mark.parametrize("pickled_kdb_path", [{"empty_df": True}], indirect=True)
-def test_kdb_init_empty_dataframe_error(pickled_kdb_path: pathlib.Path):
+@pytest.mark.parametrize("parquet_kdb_path", [{"empty_df": True}], indirect=True) # Renamed fixture
+def test_kdb_init_empty_dataframe_error(parquet_kdb_path: pathlib.Path): # Renamed fixture
     with pytest.raises(ValueError, match="Loaded database is empty"):
-        KmerStrainDatabase(pickled_kdb_path)
+        KmerStrainDatabase(parquet_kdb_path) # Use renamed fixture
 
-@pytest.mark.parametrize("pickled_kdb_path", [{"no_kmers": True}], indirect=True)
-def test_kdb_init_no_kmers_error(pickled_kdb_path: pathlib.Path):
+@pytest.mark.parametrize("parquet_kdb_path", [{"no_kmers": True}], indirect=True) # Renamed fixture
+def test_kdb_init_no_kmers_error(parquet_kdb_path: pathlib.Path): # Renamed fixture
     with pytest.raises(ValueError, match="Database contains no k-mers"):
-        KmerStrainDatabase(pickled_kdb_path)
+        KmerStrainDatabase(parquet_kdb_path) # Use renamed fixture
 
-@pytest.mark.parametrize("pickled_kdb_path", [{"no_strains": True}], indirect=True)
-def test_kdb_init_no_strains_error(pickled_kdb_path: pathlib.Path):
+@pytest.mark.parametrize("parquet_kdb_path", [{"no_strains": True}], indirect=True) # Renamed fixture
+def test_kdb_init_no_strains_error(parquet_kdb_path: pathlib.Path): # Renamed fixture
     with pytest.raises(ValueError, match="Database contains no strain information"):
-        KmerStrainDatabase(pickled_kdb_path)
+        KmerStrainDatabase(parquet_kdb_path) # Use renamed fixture
 
-@pytest.mark.parametrize("pickled_kdb_path", [{"inconsistent_kmer_len": True}], indirect=True)
-def test_kdb_init_inconsistent_kmer_length_error(pickled_kdb_path: pathlib.Path, default_kmer_length_kdb: int):
+@pytest.mark.parametrize("parquet_kdb_path", [{"inconsistent_kmer_len": True}], indirect=True) # Renamed fixture
+def test_kdb_init_inconsistent_kmer_length_error(parquet_kdb_path: pathlib.Path, default_kmer_length_kdb: int): # Renamed fixture
     with pytest.raises(ValueError, match=f"Inconsistent k-mer string length at index 1. Expected {default_kmer_length_kdb}"):
-        KmerStrainDatabase(pickled_kdb_path, expected_kmer_length=None) # Infer length
+        KmerStrainDatabase(parquet_kdb_path, expected_kmer_length=None) # Use renamed fixture
 
-@pytest.mark.parametrize("pickled_kdb_path", [{"unsupported_kmer_type": True}], indirect=True)
-def test_kdb_init_unsupported_kmer_type_error(pickled_kdb_path: pathlib.Path):
+@pytest.mark.parametrize("parquet_kdb_path", [{"unsupported_kmer_type": True}], indirect=True) # Renamed fixture
+def test_kdb_init_unsupported_kmer_type_error(parquet_kdb_path: pathlib.Path): # Renamed fixture
     with pytest.raises(TypeError, match="Unsupported k-mer type in index: <class 'int'>"):
-        KmerStrainDatabase(pickled_kdb_path)
+        KmerStrainDatabase(parquet_kdb_path) # Use renamed fixture
 
-@pytest.mark.parametrize("pickled_kdb_path", [{"custom_kmers": ["AA", "ÄA"], "kmer_type":"str"}], indirect=True)
-def test_kdb_init_inconsistent_byte_len_after_encoding_error(pickled_kdb_path: pathlib.Path, capsys):
-    # "AA" is len 2. "ÄA" is len 2 as str, but 3 bytes in utf-8 (\xc3\x84A)
-    # The code infers kmer_length=2 from "AA". Then tries to encode "ÄA".
-    # The check `if len(kmer_bytes) != self.kmer_length:` inside _load_database will fail.
-    # This was changed to a ValueError in the refactored code.
+@pytest.mark.parametrize("parquet_kdb_path", [{"custom_kmers": ["AA", "ÄA"], "kmer_type":"str"}], indirect=True) # Renamed fixture
+def test_kdb_init_inconsistent_byte_len_after_encoding_error(parquet_kdb_path: pathlib.Path, capsys): # Renamed fixture
     with pytest.raises(ValueError, match="Post-encoding/cast k-mer byte length validation failed"):
-         KmerStrainDatabase(pickled_kdb_path, expected_kmer_length=2) # Expect string length 2
+         KmerStrainDatabase(parquet_kdb_path, expected_kmer_length=2) # Use renamed fixture
 
-@pytest.mark.parametrize("pickled_kdb_path", [{"non_numeric_counts": True}], indirect=True)
-def test_kdb_init_non_numeric_counts_error(pickled_kdb_path: pathlib.Path):
+@pytest.mark.parametrize("parquet_kdb_path", [{"non_numeric_counts": True}], indirect=True) # Renamed fixture
+def test_kdb_init_non_numeric_counts_error(parquet_kdb_path: pathlib.Path): # Renamed fixture
     with pytest.raises(TypeError, match="Could not convert database values to count matrix"):
-        KmerStrainDatabase(pickled_kdb_path)
+        KmerStrainDatabase(parquet_kdb_path) # Use renamed fixture
 
-@pytest.mark.parametrize("pickled_kdb_path", [{"non_unique_kmers": True}], indirect=True)
-def test_kdb_init_non_unique_kmers_warning(pickled_kdb_path: pathlib.Path, capsys: pytest.CaptureFixture):
-    KmerStrainDatabase(pickled_kdb_path) # Should load, using last occurrence for duplicates
+@pytest.mark.parametrize("parquet_kdb_path", [{"non_unique_kmers": True}], indirect=True) # Renamed fixture
+def test_kdb_init_non_unique_kmers_warning(parquet_kdb_path: pathlib.Path, capsys: pytest.CaptureFixture): # Renamed fixture
+    KmerStrainDatabase(parquet_kdb_path) 
     captured = capsys.readouterr()
     assert "Warning: K-mer index in .* is not unique." in captured.out
 
 
 # --- Tests for get_strain_counts_for_kmer ---
-@pytest.mark.parametrize("pickled_kdb_path", [{"kmer_type": "str", "valid_data": True}], indirect=True)
+@pytest.mark.parametrize("parquet_kdb_path", [{"kmer_type": "str", "valid_data": True}], indirect=True) # Renamed fixture
 def test_kdb_get_strain_counts_for_kmer(
-    pickled_kdb_path: pathlib.Path, 
+    parquet_kdb_path: pathlib.Path, # Renamed fixture
     default_kmer_length_kdb: int, 
     strain_names_fixture_kdb: List[str], 
     sample_kmers_str_kdb: List[str]
 ):
-    db = KmerStrainDatabase(pickled_kdb_path, expected_kmer_length=default_kmer_length_kdb)
+    db = KmerStrainDatabase(parquet_kdb_path, expected_kmer_length=default_kmer_length_kdb) # Use renamed fixture
     
     known_kmer_bytes = sample_kmers_str_kdb[0].encode('utf-8')
     counts = db.get_strain_counts_for_kmer(known_kmer_bytes)
@@ -241,29 +235,26 @@ def test_kdb_get_strain_counts_for_kmer(
     unknown_kmer = ("Z" * default_kmer_length_kdb).encode('utf-8')
     assert db.get_strain_counts_for_kmer(unknown_kmer) is None
 
-    wrong_length_kmer = (sample_kmers_str_kdb[0][:-1]).encode('utf-8') # Shorter
+    wrong_length_kmer = (sample_kmers_str_kdb[0][:-1]).encode('utf-8') 
     assert db.get_strain_counts_for_kmer(wrong_length_kmer) is None
 
 
 # --- Tests for __len__ ---
-@pytest.mark.parametrize("pickled_kdb_path", [{"kmer_type": "str", "valid_data": True}], indirect=True)
-def test_kdb_len_method(pickled_kdb_path: pathlib.Path, sample_kmers_str_kdb: List[str]):
-    db = KmerStrainDatabase(pickled_kdb_path)
+@pytest.mark.parametrize("parquet_kdb_path", [{"kmer_type": "str", "valid_data": True}], indirect=True) # Renamed fixture
+def test_kdb_len_method(parquet_kdb_path: pathlib.Path, sample_kmers_str_kdb: List[str]): # Renamed fixture
+    db = KmerStrainDatabase(parquet_kdb_path) # Use renamed fixture
     assert len(db) == len(sample_kmers_str_kdb)
 
-@pytest.mark.parametrize("pickled_kdb_path", [{"non_unique_kmers": True, "custom_kmers": ["AAAA", "AAAA", "CCCC", "GGGG"], "kmer_type":"str"}], indirect=True)
-def test_kdb_len_method_non_unique_kmers(pickled_kdb_path: pathlib.Path, default_kmer_length_kdb: int):
-    # Custom kmers: "AAAA", "AAAA", "CCCC", "GGGG" (all length 4, matching default_kmer_length_kdb)
-    # Unique k-mers: "AAAA", "CCCC", "GGGG" -> 3 unique
-    # Must pass expected_kmer_length that matches the custom_kmers.
-    db = KmerStrainDatabase(pickled_kdb_path, expected_kmer_length=4)
+@pytest.mark.parametrize("parquet_kdb_path", [{"non_unique_kmers": True, "custom_kmers": ["AAAA", "AAAA", "CCCC", "GGGG"], "kmer_type":"str"}], indirect=True) # Renamed fixture
+def test_kdb_len_method_non_unique_kmers(parquet_kdb_path: pathlib.Path, default_kmer_length_kdb: int): # Renamed fixture
+    db = KmerStrainDatabase(parquet_kdb_path, expected_kmer_length=4) # Use renamed fixture
     assert len(db) == 3 
 
 
 # --- Tests for __contains__ ---
-@pytest.mark.parametrize("pickled_kdb_path", [{"kmer_type": "str", "valid_data": True}], indirect=True)
-def test_kdb_contains_method(pickled_kdb_path: pathlib.Path, sample_kmers_str_kdb: List[str], default_kmer_length_kdb: int):
-    db = KmerStrainDatabase(pickled_kdb_path)
+@pytest.mark.parametrize("parquet_kdb_path", [{"kmer_type": "str", "valid_data": True}], indirect=True) # Renamed fixture
+def test_kdb_contains_method(parquet_kdb_path: pathlib.Path, sample_kmers_str_kdb: List[str], default_kmer_length_kdb: int): # Renamed fixture
+    db = KmerStrainDatabase(parquet_kdb_path) # Use renamed fixture
     
     known_kmer_bytes = sample_kmers_str_kdb[0].encode('utf-8')
     assert known_kmer_bytes in db
@@ -271,7 +262,6 @@ def test_kdb_contains_method(pickled_kdb_path: pathlib.Path, sample_kmers_str_kd
     unknown_kmer = ("Z" * default_kmer_length_kdb).encode('utf-8')
     assert unknown_kmer not in db
     
-    # Test with string - Kmer type alias is bytes, so this should be False
     known_kmer_as_str = sample_kmers_str_kdb[0]
-    assert known_kmer_as_str not in db # type: ignore # Test behavior with incorrect type
+    assert known_kmer_as_str not in db # type: ignore 
 ```

--- a/tests/test_strain_kmer_db.py
+++ b/tests/test_strain_kmer_db.py
@@ -7,7 +7,7 @@ import pytest
 import pandas as pd
 import numpy as np
 import pathlib
-import pickle
+# import pickle # Pickle is no longer used directly for db files
 from typing import List, Union, Optional
 from unittest.mock import patch, MagicMock
 
@@ -71,7 +71,7 @@ def sample_kmers_bytes_skdb(sample_kmers_str_skdb: List[str]) -> List[Kmer]:
 
 
 @pytest.fixture
-def pickled_skdb_path(
+def parquet_skdb_path( # Renamed fixture
     tmp_path: pathlib.Path,
     request: pytest.FixtureRequest,
     default_kmer_length_skdb: int,
@@ -80,10 +80,9 @@ def pickled_skdb_path(
     sample_kmers_bytes_skdb: List[Kmer],
 ) -> pathlib.Path:
     params = getattr(request, "param", {})
-    # Unique name to avoid clashes if other tests run in same tmp_path session
-    db_file = tmp_path / f"test_strain_kmer_db_{request.node.name}.pkl"
+    db_file = tmp_path / f"test_strain_kmer_db_{request.node.name}.parquet" # Changed extension
 
-    df_to_pickle: pd.DataFrame
+    df_to_save: pd.DataFrame # Renamed variable for clarity
     kmer_type = params.get("kmer_type", "str")
 
     kmers_for_df: List[Union[str, bytes]]
@@ -98,11 +97,11 @@ def pickled_skdb_path(
     strains = params.get("custom_strains", strain_names_fixture_skdb)
 
     if params.get("empty_df", False):
-        df_to_pickle = create_dummy_dataframe_for_skdb([], [])
+        df_to_save = create_dummy_dataframe_for_skdb([], [])
     elif params.get("no_kmers", False):
-        df_to_pickle = create_dummy_dataframe_for_skdb([], strains)
+        df_to_save = create_dummy_dataframe_for_skdb([], strains)
     elif params.get("no_strains", False):
-        df_to_pickle = create_dummy_dataframe_for_skdb(kmers_for_df, [])
+        df_to_save = create_dummy_dataframe_for_skdb(kmers_for_df, [])
     elif params.get("inconsistent_kmer_len", False):
         if kmer_type == "str":
             kmers_for_df = [
@@ -114,48 +113,46 @@ def pickled_skdb_path(
                 sample_kmers_bytes_skdb[0],
                 sample_kmers_bytes_skdb[1][: default_kmer_length_skdb - 1],
             ]
-        df_to_pickle = create_dummy_dataframe_for_skdb(kmers_for_df, strains)
+        df_to_save = create_dummy_dataframe_for_skdb(kmers_for_df, strains)
     elif params.get("unsupported_kmer_type", False):
         kmers_for_df = [123, 456]  # type: ignore
-        df_to_pickle = create_dummy_dataframe_for_skdb(kmers_for_df, strains)
+        df_to_save = create_dummy_dataframe_for_skdb(kmers_for_df, strains)
     elif params.get("non_numeric_counts", False):
-        # Ensure kmers_for_df has at least 2 elements if counts_data is 2xN
         target_kmer_list = kmers_for_df
         if len(kmers_for_df) < 2 and len(kmers_for_df) > 0:
-            target_kmer_list = [kmers_for_df[0], kmers_for_df[0]]  # dummy up
+            target_kmer_list = [kmers_for_df[0], kmers_for_df[0]] 
         elif not kmers_for_df:
-            target_kmer_list = ["AAAA", "CCCC"]  # if empty
+            target_kmer_list = ["AAAA", "CCCC"] 
 
         counts_data = np.array([["val1", "val2"], ["val3", "val4"]], dtype=object)
-        df_to_pickle = create_dummy_dataframe_for_skdb(
+        df_to_save = create_dummy_dataframe_for_skdb(
             target_kmer_list[:2], strains, counts_data
         )
     elif params.get("non_unique_kmers", False):
         kmers_for_df = [kmers_for_df[0], kmers_for_df[0]] + (
             kmers_for_df[1:] if len(kmers_for_df) > 1 else []
         )
-        df_to_pickle = create_dummy_dataframe_for_skdb(kmers_for_df, strains)
+        df_to_save = create_dummy_dataframe_for_skdb(kmers_for_df, strains)
     else:
-        df_to_pickle = create_dummy_dataframe_for_skdb(
+        df_to_save = create_dummy_dataframe_for_skdb(
             kmers_for_df, strains, counts_data
         )
 
-    with open(db_file, "wb") as f:
-        pickle.dump(df_to_pickle, f)
+    df_to_save.to_parquet(db_file, index=True) # Changed saving method
     return db_file
 
 
 # --- Tests for __init__ and _load_database (using StrainKmerDb) ---
 
 
-@pytest.mark.parametrize("pickled_skdb_path", [{"kmer_type": "str"}], indirect=True)
+@pytest.mark.parametrize("parquet_skdb_path", [{"kmer_type": "str"}], indirect=True) # Renamed fixture
 def test_skdb_init_success_str_kmers(
-    pickled_skdb_path: pathlib.Path,
+    parquet_skdb_path: pathlib.Path, # Renamed fixture
     default_kmer_length_skdb: int,
     strain_names_fixture_skdb: List[str],
     sample_kmers_str_skdb: List[str],
 ):
-    db = StrainKmerDb(pickled_skdb_path, expected_kmer_length=default_kmer_length_skdb)
+    db = StrainKmerDb(parquet_skdb_path, expected_kmer_length=default_kmer_length_skdb) # Use renamed fixture
     assert db.kmer_length == default_kmer_length_skdb
     assert db.num_strains == len(strain_names_fixture_skdb)
     assert db.num_kmers == len(sample_kmers_str_skdb)
@@ -163,27 +160,27 @@ def test_skdb_init_success_str_kmers(
     assert db.strain_names == strain_names_fixture_skdb
 
 
-@pytest.mark.parametrize("pickled_skdb_path", [{"kmer_type": "bytes"}], indirect=True)
+@pytest.mark.parametrize("parquet_skdb_path", [{"kmer_type": "bytes"}], indirect=True) # Renamed fixture
 def test_skdb_init_success_bytes_kmers(
-    pickled_skdb_path: pathlib.Path,
+    parquet_skdb_path: pathlib.Path, # Renamed fixture
     default_kmer_length_skdb: int,
     strain_names_fixture_skdb: List[str],
     sample_kmers_bytes_skdb: List[Kmer],
 ):
-    db = StrainKmerDb(pickled_skdb_path, expected_kmer_length=default_kmer_length_skdb)
+    db = StrainKmerDb(parquet_skdb_path, expected_kmer_length=default_kmer_length_skdb) # Use renamed fixture
     assert db.kmer_length == default_kmer_length_skdb
     assert db.num_strains == len(strain_names_fixture_skdb)
     assert db.num_kmers == len(sample_kmers_bytes_skdb)
     assert all(isinstance(k, bytes) for k in db.kmer_to_counts_map.keys())
 
 
-@pytest.mark.parametrize("pickled_skdb_path", [{"kmer_type": "str"}], indirect=True)
+@pytest.mark.parametrize("parquet_skdb_path", [{"kmer_type": "str"}], indirect=True) # Renamed fixture
 def test_skdb_init_kmer_length_inferred(
-    pickled_skdb_path: pathlib.Path,
+    parquet_skdb_path: pathlib.Path, # Renamed fixture
     default_kmer_length_skdb: int,
     capsys: pytest.CaptureFixture,
 ):
-    db = StrainKmerDb(pickled_skdb_path, expected_kmer_length=None)
+    db = StrainKmerDb(parquet_skdb_path, expected_kmer_length=None) # Use renamed fixture
     assert db.kmer_length == default_kmer_length_skdb
     captured = capsys.readouterr()
     assert (
@@ -192,13 +189,13 @@ def test_skdb_init_kmer_length_inferred(
     )
 
 
-@pytest.mark.parametrize("pickled_skdb_path", [{"kmer_type": "str"}], indirect=True)
+@pytest.mark.parametrize("parquet_skdb_path", [{"kmer_type": "str"}], indirect=True) # Renamed fixture
 def test_skdb_init_kmer_length_mismatch_error(
-    pickled_skdb_path: pathlib.Path, default_kmer_length_skdb: int
+    parquet_skdb_path: pathlib.Path, default_kmer_length_skdb: int # Renamed fixture
 ):
     with pytest.raises(ValueError, match="does not match length of first k-mer"):
         StrainKmerDb(
-            pickled_skdb_path, expected_kmer_length=default_kmer_length_skdb + 1
+            parquet_skdb_path, expected_kmer_length=default_kmer_length_skdb + 1 # Use renamed fixture
         )
 
 
@@ -206,98 +203,99 @@ def test_skdb_init_file_not_found_error():
     with pytest.raises(
         FileNotFoundError, match="Database file not found or is not a file:"
     ):
-        StrainKmerDb("nonexistent_skdb.pkl")
+        StrainKmerDb("nonexistent_skdb.parquet") # Updated extension
 
 
-@pytest.mark.parametrize("error_type", [EOFError, pickle.UnpicklingError])
-@patch("pandas.read_pickle")
-def test_skdb_init_pickle_read_error(
-    mock_read_pickle: MagicMock, error_type: Exception, tmp_path: pathlib.Path
+@patch("pandas.read_parquet") # Patched to read_parquet
+def test_skdb_init_parquet_read_error( # Renamed test
+    mock_read_parquet: MagicMock, tmp_path: pathlib.Path # Renamed mock
 ):
-    mock_read_pickle.side_effect = error_type
-    db_file = tmp_path / "bad_pickle_skdb.pkl"
+    # Simulate an error that pd.read_parquet might raise
+    mock_read_parquet.side_effect = ValueError("Simulated Parquet read error") 
+    db_file = tmp_path / "bad_parquet_skdb.parquet" # Updated extension
     db_file.touch()
-    with pytest.raises(RuntimeError, match="Could not read or unpickle database file"):
+    # Match the error message from StrainKmerDb._load_database
+    with pytest.raises(RuntimeError, match="Failed to read or process Parquet database file"): 
         StrainKmerDb(db_file)
 
 
 # ... (other error condition tests from test_kmer_database.py, adapted for StrainKmerDb) ...
 
 
-@pytest.mark.parametrize("pickled_skdb_path", [{"empty_df": True}], indirect=True)
-def test_skdb_init_empty_dataframe_error(pickled_skdb_path: pathlib.Path):
+@pytest.mark.parametrize("parquet_skdb_path", [{"empty_df": True}], indirect=True) # Renamed fixture
+def test_skdb_init_empty_dataframe_error(parquet_skdb_path: pathlib.Path): # Renamed fixture
     with pytest.raises(ValueError, match="Loaded database is empty"):
-        StrainKmerDb(pickled_skdb_path)
+        StrainKmerDb(parquet_skdb_path) # Use renamed fixture
 
 
-@pytest.mark.parametrize("pickled_skdb_path", [{"no_kmers": True}], indirect=True)
-def test_skdb_init_no_kmers_error(pickled_skdb_path: pathlib.Path):
+@pytest.mark.parametrize("parquet_skdb_path", [{"no_kmers": True}], indirect=True) # Renamed fixture
+def test_skdb_init_no_kmers_error(parquet_skdb_path: pathlib.Path): # Renamed fixture
     with pytest.raises(ValueError, match="Database contains no k-mers"):
-        StrainKmerDb(pickled_skdb_path)
+        StrainKmerDb(parquet_skdb_path) # Use renamed fixture
 
 
-@pytest.mark.parametrize("pickled_skdb_path", [{"no_strains": True}], indirect=True)
-def test_skdb_init_no_strains_error(pickled_skdb_path: pathlib.Path):
+@pytest.mark.parametrize("parquet_skdb_path", [{"no_strains": True}], indirect=True) # Renamed fixture
+def test_skdb_init_no_strains_error(parquet_skdb_path: pathlib.Path): # Renamed fixture
     with pytest.raises(ValueError, match="Database contains no strain information"):
-        StrainKmerDb(pickled_skdb_path)
+        StrainKmerDb(parquet_skdb_path) # Use renamed fixture
 
 
 @pytest.mark.parametrize(
-    "pickled_skdb_path",
+    "parquet_skdb_path", # Renamed fixture
     [{"inconsistent_kmer_len": True, "kmer_type": "str"}],
     indirect=True,
 )
 def test_skdb_init_inconsistent_str_kmer_length_error(
-    pickled_skdb_path: pathlib.Path, default_kmer_length_skdb: int
+    parquet_skdb_path: pathlib.Path, default_kmer_length_skdb: int # Renamed fixture
 ):
     with pytest.raises(
         ValueError,
         match=f"Inconsistent k-mer string length at index 1. Expected {default_kmer_length_skdb}",
     ):
-        StrainKmerDb(pickled_skdb_path, expected_kmer_length=None)
+        StrainKmerDb(parquet_skdb_path, expected_kmer_length=None) # Use renamed fixture
 
 
 @pytest.mark.parametrize(
-    "pickled_skdb_path", [{"unsupported_kmer_type": True}], indirect=True
+    "parquet_skdb_path", [{"unsupported_kmer_type": True}], indirect=True # Renamed fixture
 )
-def test_skdb_init_unsupported_kmer_type_error(pickled_skdb_path: pathlib.Path):
+def test_skdb_init_unsupported_kmer_type_error(parquet_skdb_path: pathlib.Path): # Renamed fixture
     with pytest.raises(
         TypeError, match="Unsupported k-mer type in index: <class 'int'>"
     ):
-        StrainKmerDb(pickled_skdb_path)
+        StrainKmerDb(parquet_skdb_path) # Use renamed fixture
 
 
 @pytest.mark.parametrize(
-    "pickled_skdb_path", [{"non_numeric_counts": True}], indirect=True
+    "parquet_skdb_path", [{"non_numeric_counts": True}], indirect=True # Renamed fixture
 )
-def test_skdb_init_non_numeric_counts_error(pickled_skdb_path: pathlib.Path):
+def test_skdb_init_non_numeric_counts_error(parquet_skdb_path: pathlib.Path): # Renamed fixture
     with pytest.raises(
         TypeError, match="Could not convert database values to count matrix"
     ):
-        StrainKmerDb(pickled_skdb_path)
+        StrainKmerDb(parquet_skdb_path) # Use renamed fixture
 
 
 @pytest.mark.parametrize(
-    "pickled_skdb_path", [{"non_unique_kmers": True}], indirect=True
+    "parquet_skdb_path", [{"non_unique_kmers": True}], indirect=True # Renamed fixture
 )
 def test_skdb_init_non_unique_kmers_warning(
-    pickled_skdb_path: pathlib.Path, capsys: pytest.CaptureFixture
+    parquet_skdb_path: pathlib.Path, capsys: pytest.CaptureFixture # Renamed fixture
 ):
-    StrainKmerDb(pickled_skdb_path)
+    StrainKmerDb(parquet_skdb_path) # Use renamed fixture
     captured = capsys.readouterr()
     assert "Warning: K-mer index in .* is not unique." in captured.out
 
 
 # --- Tests for get_strain_counts_for_kmer (adapted from lookup_kmer) ---
 @pytest.mark.parametrize(
-    "pickled_skdb_path",
+    "parquet_skdb_path", # Renamed fixture
     [{"kmer_type": "str", "custom_kmers": ["ATGC", "CGTA"]}],
     indirect=True,
 )
 def test_skdb_get_strain_counts_for_kmer(
-    pickled_skdb_path: pathlib.Path, strain_names_fixture_skdb: List[str]
+    parquet_skdb_path: pathlib.Path, strain_names_fixture_skdb: List[str] # Renamed fixture
 ):
-    db = StrainKmerDb(pickled_skdb_path, expected_kmer_length=4)
+    db = StrainKmerDb(parquet_skdb_path, expected_kmer_length=4) # Use renamed fixture
 
     known_kmer_bytes = b"ATGC"
     counts = db.get_strain_counts_for_kmer(known_kmer_bytes)
@@ -312,28 +310,26 @@ def test_skdb_get_strain_counts_for_kmer(
     incorrect_length_kmer = b"ATG"
     assert db.get_strain_counts_for_kmer(incorrect_length_kmer) is None
 
-    # Test with string input (should be handled gracefully or raise TypeError)
-    # Current consolidated version's get_strain_counts_for_kmer returns None for non-bytes
     assert db.get_strain_counts_for_kmer("ATGC") is None  # type: ignore
 
 
 # --- Tests for __len__ ---
-@pytest.mark.parametrize("pickled_skdb_path", [{"kmer_type": "str"}], indirect=True)
+@pytest.mark.parametrize("parquet_skdb_path", [{"kmer_type": "str"}], indirect=True) # Renamed fixture
 def test_skdb_len_method(
-    pickled_skdb_path: pathlib.Path, sample_kmers_str_skdb: List[str]
+    parquet_skdb_path: pathlib.Path, sample_kmers_str_skdb: List[str] # Renamed fixture
 ):
-    db = StrainKmerDb(pickled_skdb_path)
+    db = StrainKmerDb(parquet_skdb_path) # Use renamed fixture
     assert len(db) == len(sample_kmers_str_skdb)
 
 
 # --- Tests for __contains__ ---
-@pytest.mark.parametrize("pickled_skdb_path", [{"kmer_type": "str"}], indirect=True)
+@pytest.mark.parametrize("parquet_skdb_path", [{"kmer_type": "str"}], indirect=True) # Renamed fixture
 def test_skdb_contains_method(
-    pickled_skdb_path: pathlib.Path,
+    parquet_skdb_path: pathlib.Path, # Renamed fixture
     sample_kmers_str_skdb: List[str],
     default_kmer_length_skdb: int,
 ):
-    db = StrainKmerDb(pickled_skdb_path)
+    db = StrainKmerDb(parquet_skdb_path) # Use renamed fixture
 
     known_kmer_bytes = sample_kmers_str_skdb[0].encode("utf-8")
     assert known_kmer_bytes in db
@@ -342,13 +338,12 @@ def test_skdb_contains_method(
     assert unknown_kmer not in db
 
     known_kmer_as_str = sample_kmers_str_skdb[0]
-    # Consolidated __contains__ checks isinstance(kmer, bytes)
     assert known_kmer_as_str not in db  # type: ignore
 
 
 # --- Tests for get_database_stats (New tests for merged method) ---
 @pytest.mark.parametrize(
-    "pickled_skdb_path",
+    "parquet_skdb_path", # Renamed fixture
     [
         {
             "kmer_type": "str",
@@ -358,28 +353,28 @@ def test_skdb_contains_method(
     indirect=True,
 )
 def test_skdb_get_database_stats(
-    pickled_skdb_path: pathlib.Path,
-    default_kmer_length_skdb: int,  # kmer_length is 4
+    parquet_skdb_path: pathlib.Path, # Renamed fixture
+    default_kmer_length_skdb: int, 
     strain_names_fixture_skdb: List[str],
 ):
-    db = StrainKmerDb(pickled_skdb_path, expected_kmer_length=default_kmer_length_skdb)
+    db = StrainKmerDb(parquet_skdb_path, expected_kmer_length=default_kmer_length_skdb) # Use renamed fixture
     stats = db.get_database_stats()
 
     assert stats["num_strains"] == len(strain_names_fixture_skdb)
-    assert stats["num_kmers"] == 6  # from custom_kmers
+    assert stats["num_kmers"] == 6 
     assert stats["kmer_length"] == default_kmer_length_skdb
-    assert stats["database_filepath"] == str(pickled_skdb_path.resolve())
+    assert stats["database_filepath"] == str(parquet_skdb_path.resolve()) # Use renamed fixture
     assert len(stats["strain_names_preview"]) <= 5
     assert stats["strain_names_preview"] == strain_names_fixture_skdb[:5]
     assert stats["total_strain_names"] == len(strain_names_fixture_skdb)
 
 
 # --- Tests for validate_kmer_length (New tests for merged method) ---
-@pytest.mark.parametrize("pickled_skdb_path", [{"kmer_type": "str"}], indirect=True)
+@pytest.mark.parametrize("parquet_skdb_path", [{"kmer_type": "str"}], indirect=True) # Renamed fixture
 def test_skdb_validate_kmer_length(
-    pickled_skdb_path: pathlib.Path, default_kmer_length_skdb: int
+    parquet_skdb_path: pathlib.Path, default_kmer_length_skdb: int # Renamed fixture
 ):
-    db = StrainKmerDb(pickled_skdb_path, expected_kmer_length=default_kmer_length_skdb)
+    db = StrainKmerDb(parquet_skdb_path, expected_kmer_length=default_kmer_length_skdb) # Use renamed fixture
 
     correct_len_str = "X" * default_kmer_length_skdb
     incorrect_len_str = "X" * (default_kmer_length_skdb - 1)


### PR DESCRIPTION
This commit changes the primary storage format for your k-mer databases from pickle (.pkl) to Parquet (.parquet).

Key changes include:
- Modified `scripts/strainr-db.py` to generate databases in Parquet format.
- Updated `src/strainr/database.py` (StrainKmerDatabase) and `src/strainr/kmer_database.py` (StrainKmerDb) to load and handle Parquet files.
- Updated `scripts/strainr-counters.py` and `scripts/strainr-dbpan.py` to expect and/or produce Parquet format where k-mer databases are involved.
- Added a conversion script `src/strainr/convert_db_format.py` to migrate existing .pkl databases to .parquet.
- Updated all relevant test suites (`tests/test_database.py`, `tests/test_strain_kmer_db.py`, `tests/test_kmer_database.py`) to use Parquet for test data and mocks.
- Updated `README.md` to reflect Parquet usage.

Known Issues & Potential Inconsistencies:
- Due to some challenges I encountered during development, help texts and descriptions within the following files might still incorrectly refer to "pickle" or ".pkl" format for the database. These should be manually reviewed:
    - `src/strainr/classify.py` (Pydantic model `CliArgs` for `db_path` description)
    - `src/strainr/parameter_config.py` (argparse help text for `--db` and potentially `--save-raw-hits`)
- The `--save-raw-hits` option in `src/strainr/parameter_config.py` and `src/strainr/classify.py` had its help text changed to be generic ("output files (format may vary)"). The actual output format of these files (if they were pickle) should be reviewed and potentially changed to a more standard format like CSV or Parquet in future work.

Future Refactoring Considerations (as per your feedback):
- Consolidate database handling logic:
    - Merge `src/strainr/kmer_database.py` and `src/strainr/database.py`.
    - Potentially merge or better integrate `scripts/strainr-db.py` (the database builder) with the core database loading module. Consider renaming `scripts/strainr-db.py` to `build_db.py` or similar.
- Review the roles of `StrainKmerDb` vs. `StrainKmerDatabase` and the internal `StrainDatabase` in `strainr-counters.py` to simplify and unify database interactions.