### PR TITLE
Fix inconsistent return annotation for open_file_transparently

### DIFF
--- a/src/strainr/utils.py
+++ b/src/strainr/utils.py
@@ -4,7 +4,7 @@ import gzip
 import mimetypes
 import pathlib
 import pickle
-from typing import Dict, List, TextIO, Tuple, Union
+from typing import Dict, IO, List, Tuple, Union, Any
 
 import numpy as np  # For type hinting np.ndarray
 import pandas as pd
@@ -13,7 +13,7 @@ from Bio.Seq import Seq
 
 def open_file_transparently(
     file_path: Union[str, pathlib.Path], mode: str = "rt"
-) -> TextIO:
+) -> IO[Any]:
     """Opens a file, transparently handling gzip compression.
 
     Infers compression from file extension. Defaults to text read mode.


### PR DESCRIPTION
## Summary
- generalize `open_file_transparently` return type

## Testing
- `pytest -q` *(fails: 'local_filename' column not found in metadata)*

------
https://chatgpt.com/codex/tasks/task_e_6840c2d8c1d0833393a552eddab3f2e3