### PR TITLE
Remove duplicated tests

### DIFF
--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -354,22 +354,6 @@ def test_generate_report_string_empty(calculator_fixture: AbundanceCalculator):
         calculator_fixture.generate_report_string({})
         == "No strains found above the abundance threshold."
     )
-    rel_ab = {"StrainC": 0.3, "StrainA": 0.5, "StrainB": 0.2}
-    formatted = calculator_fixture.apply_threshold_and_format(
-        rel_ab, sort_by_abundance=False
-    )
-    # Expected order: StrainA, StrainB, StrainC (alphabetical)
-    assert list(formatted.keys()) == ["StrainA", "StrainB", "StrainC"]
-
-
-# --- Test generate_report_string ---
-
-
-def test_generate_report_string_empty(calculator_fixture: AbundanceCalculator):
-    assert (
-        calculator_fixture.generate_report_string({})
-        == "No strains found above the abundance threshold."
-    )
 
 
 def test_generate_report_string_basic_formatting(

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -107,18 +107,6 @@ def test_genomic_sequence_getitem(genomic_sequence_fixture: GenomicSequence):
         _ = genomic_sequence_fixture[len(genomic_sequence_fixture.sequence_data)]
 
 
-def test_genomic_sequence_length(
-    genomic_sequence_fixture: GenomicSequence, valid_dna_bytes_fixture: bytes
-):
-    assert len(genomic_sequence_fixture) == len(valid_dna_bytes_fixture)
-
-
-def test_genomic_sequence_string_representation(
-    genomic_sequence_fixture: GenomicSequence, valid_dna_bytes_fixture: bytes
-):
-    assert str(genomic_sequence_fixture) == valid_dna_bytes_fixture.decode("ascii")
-
-
 def test_genomic_sequence_getitem(genomic_sequence_fixture: GenomicSequence):
     assert genomic_sequence_fixture[0] == "A"
     assert genomic_sequence_fixture[-1] == "T"


### PR DESCRIPTION
## Summary
- clean up duplicate tests in `tests/test_sequence.py`
- remove redundant definition of `test_generate_report_string_empty`

## Testing
- `pytest -q` *(fails: TestDatabaseBuilder::test_create_database_custom_genomes, TestDatabaseBuilder::test_filter_genomes_unique_taxid_basic)*

------
https://chatgpt.com/codex/tasks/task_e_6840c2cc993483338e064a01d655f5e7