### PR TITLE
Fix: Resolve freezing issue in parallel Rust k-mer counting.

### DIFF
--- a/strainr/build_db.py
+++ b/strainr/build_db.py
@@ -806,25 +806,30 @@ class DatabaseBuilder:
                             kmers_from_seq = extract_func(
                                 seq_bytes.upper(), kmer_length
                             )
+                            logger.debug(f"Received {len(kmers_from_seq)} k-mers from Rust for {genome_file} (record: {record.id})")
                             if skip_n_kmers:
                                 kmers_from_seq = [
                                     kmer for kmer in kmers_from_seq if b"N" not in kmer
                                 ]
                             strain_kmers.update(kmers_from_seq)
-                        except Exception:
+                        except Exception as rust_exc:
+                            logger.warning(f"Rust k-mer extraction failed for {genome_file} (record: {record.id}): {rust_exc}. Falling back to Python.")
                             # Fallback to Python implementation
                             kmers_from_seq = (
                                 DatabaseBuilder._py_extract_canonical_kmers_static(
                                     seq_bytes, kmer_length, skip_n_kmers
                                 )
                             )
+                            logger.debug(f"Received {len(kmers_from_seq)} k-mers from Python fallback for {genome_file} (record: {record.id})")
                             strain_kmers.update(kmers_from_seq)
                     else:
+                        # Python only path
                         kmers_from_seq = (
                             DatabaseBuilder._py_extract_canonical_kmers_static(
                                 seq_bytes, kmer_length, skip_n_kmers
                             )
                         )
+                        logger.debug(f"Received {len(kmers_from_seq)} k-mers from Python for {genome_file} (record: {record.id})")
                         strain_kmers.update(kmers_from_seq)
 
         except Exception as e:


### PR DESCRIPTION
The `build_db` process was freezing during parallel k-mer extraction when using the Rust implementation. This was likely due to issues with how the `needletail` crate was used for processing raw sequence bytes.

This commit addresses the issue by:
1. Refactoring the `extract_kmers_rs` function in the Rust crate (`kmer_counter_rs`) to manually generate and canonicalize k-mers from raw sequence bytes. This bypasses `needletail` for this specific operation, making the process more direct and less prone to hidden issues within the library for this use case.
2. Retaining `needletail` for the file-based k-mer counting function (`extract_kmer_rs` singular) where it is more appropriate.
3. Enhancing logging in both the Rust k-mer extraction code and the calling Python code (`strainr/build_db.py`). This includes:
    - Logging the number of k-mers skipped due to invalid characters (e.g., 'N').
    - Logging the number of k-mers successfully extracted and passed back to Python.
    - More detailed summary logs in Rust.

These changes aim to make the k-mer extraction process more robust and provide better diagnostics.