### PR TITLE
Fix: Pass file path to Rust k-mer extraction

### DIFF
--- a/strainr/build_db.py
+++ b/strainr/build_db.py
@@ -893,9 +893,9 @@ class DatabaseBuilder:
 
                     if extract_func is not None:
                         try:
-                            # Call Rust function with three arguments: (sequence_bytes, k, skip_n_kmers)
+                            # Call Rust function with file path and kmer_length
                             kmers_from_seq = extract_func(
-                                seq_bytes.upper(), kmer_length
+                                str(genome_file), kmer_length
                             )
                             logger.debug(
                                 f"Received {len(kmers_from_seq)} k-mers from Rust for {genome_file} (record: {record.id})"


### PR DESCRIPTION
The Rust k-mer extraction function `extract_kmer_rs` expects a file path as its first argument, but it was being called with sequence data. This caused a type error and prevented the Rust implementation from being used.

I've fixed the issue by passing the genome file path (converted to a string) to `extract_kmer_rs` in the `_process_and_write_kmers_worker` function in `strainr/build_db.py`. The existing error handling ensures that the system falls back to the Python implementation if the Rust call fails for any reason.