### PR TITLE
Refactor: Use uncompressed temporary files for speed

### DIFF
--- a/strainr/build_db.py
+++ b/strainr/build_db.py
@@ -27,6 +27,7 @@ import logging
 import multiprocessing as mp
 import pathlib
 import shutil
+import shlex
 import subprocess
 import sys
 import gzip
@@ -681,8 +682,8 @@ class DatabaseBuilder:
 
         logger.info("Map phase completed. All k-mers written to temporary files.")
 
-        # --- Enhanced check for expected .part.gz files ---
-        expected_part_files = [temp_dir / f"{i}.part.gz" for i in range(num_genomes)]
+        # --- Enhanced check for expected .part.txt files ---
+        expected_part_files = [temp_dir / f"{i}.part.txt" for i in range(num_genomes)]
         problematic_files = []
         missing_files_list = []
         empty_files_list = []
@@ -713,14 +714,18 @@ class DatabaseBuilder:
             all_parts_file = temp_dir / "all_kmer_parts.tsv"
             sorted_parts_file = temp_dir / "all_kmer_parts.sorted.tsv"
 
-            logger.info(f"Fast concatenating temporary files into {all_parts_file}...")
-            # Optimized concatenation using system commands (much faster than Python shutil)
-            part_files = list(temp_dir.glob("*.part.gz"))
-            if len(part_files) > 100:  # For many files, use find + zcat
-                concat_command = f"find {temp_dir} -name '*.part.gz' -exec zcat {{}} + > {all_parts_file}"
-            else:  # For fewer files, direct zcat
-                part_paths = " ".join(str(f) for f in part_files)
-                concat_command = f"zcat {part_paths} > {all_parts_file}"
+            logger.info(f"Concatenating temporary part files into {all_parts_file}...")
+            part_files = list(temp_dir.glob("*.part.txt"))
+            if len(part_files) > 100:  # For many files, use find + cat (robustly)
+                # Using print0 and xargs -0 for robustness with filenames containing special characters or spaces.
+                # The '--' ensures that even if a filename starts with '-', cat doesn't interpret it as an option.
+                concat_command = f"find {temp_dir} -name '*.part.txt' -print0 | xargs -0 cat -- > {all_parts_file}"
+            else:  # For fewer files, direct cat
+                if not part_files: # Handle case where there are no files to avoid error with empty command
+                    concat_command = f"touch {all_parts_file}" # Create an empty file if no parts exist
+                else:
+                    part_paths_str = " ".join(shlex.quote(str(f)) for f in part_files) # Use shlex.quote for safety
+                    concat_command = f"cat {part_paths_str} > {all_parts_file}"
 
             logger.info(f"Executing concatenation command: {concat_command}")
             concat_process = subprocess.run(
@@ -737,10 +742,10 @@ class DatabaseBuilder:
             logger.info("Concatenation completed successfully.")
 
             logger.info("Optimized sorting all k-mer parts on disk (parallel sort)...")
-            # Use parallel sort with memory buffer and compression for much better performance
+            # Use parallel sort with memory buffer. Compression is removed as inputs are plain text.
             sort_command = (
                 f"LC_ALL=C sort -k1,1 --parallel={self.args.procs} "
-                f"-S 2G --compress-program=gzip {all_parts_file} -o {sorted_parts_file}"
+                f"-S 2G {all_parts_file} -o {sorted_parts_file}"
             )
             logger.info(f"Executing sort command: {sort_command}")
             sort_process = subprocess.run(
@@ -865,8 +870,8 @@ class DatabaseBuilder:
 
         # Check for required external commands first
         try:
-            check_external_commands(["sort", "zcat"])
-            logger.info("External commands 'sort' and 'zcat' found.")
+            check_external_commands(["sort", "cat", "find", "xargs", "touch"])
+            logger.info("External commands 'sort', 'cat', 'find', 'xargs', 'touch' found.")
         except FileNotFoundError as e:
             logger.error(f"Missing required external command: {e}")
             # Depending on desired behavior, you might re-raise or sys.exit
@@ -932,11 +937,10 @@ class DatabaseBuilder:
                 rust_kmers_map = _extract_kmers_func(str(genome_file), kmer_length, not skip_n_kmers)
 
                 # The Rust function now handles N-kmer processing based on the new flag.
-                # The keys of rust_kmers_map are the k-mers to be added directly.
-                raw_kmers_from_rust = rust_kmers_map.keys()
-                strain_kmers.update(raw_kmers_from_rust)
+                # The keys of rust_kmers_map are the k-mers.
+                # No longer update strain_kmers here for the Rust path.
                 logger.info(
-                    f"Successfully extracted {len(strain_kmers)} k-mers from {genome_file} using Rust."
+                    f"Successfully extracted {len(rust_kmers_map)} unique k-mers from {genome_file} using Rust."
                 )
                 rust_succeeded = True
             except Exception as rust_exc: # pragma: no cover
@@ -983,29 +987,49 @@ class DatabaseBuilder:
                 # Raise exception so the main process knows this worker failed
                 raise # 16 spaces
 
-        # Continue with writing k-mers to file (common to both paths)
-        # Write to compressed temp file for better I/O performance
-        temp_file_path = temp_dir / f"{strain_idx}.part.gz"
-        logger.info(f"Worker for strain_idx {strain_idx}: Starting to write {len(strain_kmers)} k-mers to {temp_file_path}")
+        # Writing k-mers to file
+        temp_file_path = temp_dir / f"{strain_idx}.part.txt"
+
+        kmer_source_iterator = None
+        num_kmers_to_write = 0
+
+        if rust_succeeded:
+            # This check implies rust_kmers_map is defined
+            logger.info(f"Worker for strain_idx {strain_idx}: Preparing to write {len(rust_kmers_map)} k-mers (from Rust) to {temp_file_path}")
+            kmer_source_iterator = iter(rust_kmers_map.keys()) # Iterate over keys from Rust result
+            num_kmers_to_write = len(rust_kmers_map)
+        else:
+            # This implies Python fallback was used, or Rust was not attempted.
+            # strain_kmers set should be populated by the Python logic.
+            logger.info(f"Worker for strain_idx {strain_idx}: Preparing to write {len(strain_kmers)} k-mers (from Python) to {temp_file_path}")
+            kmer_source_iterator = iter(strain_kmers)
+            num_kmers_to_write = len(strain_kmers)
 
         batch_size = 10000  # Write 10,000 lines at a time
         batch = []
         total_written_count = 0
 
-        with gzip.open(temp_file_path, "wb") as f_out: # Note "wb"
-            for kmer_bytes in strain_kmers:
-                line = f"{kmer_bytes.hex()}\t{strain_idx}\n"
-                batch.append(line.encode('utf-8')) # Encode to bytes
-                total_written_count += 1
-                if len(batch) >= batch_size:
+        if num_kmers_to_write == 0:
+            logger.info(f"Worker for strain_idx {strain_idx}: No k-mers to write for {genome_file}.")
+            # Create an empty .part.txt file as the downstream process expects it
+            with open(temp_file_path, "w", encoding='utf-8') as f_out: # Ensure this uses the new open
+                pass # Creates an empty file
+        else:
+            with open(temp_file_path, "w", encoding='utf-8') as f_out: # Note "w" and encoding
+                for kmer_bytes in kmer_source_iterator:
+                    line = f"{kmer_bytes.hex()}\t{strain_idx}\n"
+                    batch.append(line) # Line is already a string, no encoding needed here
+                    total_written_count += 1
+                    if len(batch) >= batch_size:
+                        f_out.writelines(batch)
+                        batch = []
+
+                    # Log every 10 batches, and include total expected for context
+                    if total_written_count > 0 and total_written_count % (batch_size * 10) == 0:
+                        logger.info(f"Worker for strain_idx {strain_idx}: Written {total_written_count}/{num_kmers_to_write} k-mers so far to {temp_file_path}")
+
+                if batch: # Write any remaining lines
                     f_out.writelines(batch)
-                    batch = []
-
-                if total_written_count > 0 and total_written_count % (batch_size * 10) == 0:
-                    logger.info(f"Worker for strain_idx {strain_idx}: Written {total_written_count} k-mers so far to {temp_file_path}")
-
-            if batch: # Write any remaining lines
-                f_out.writelines(batch)
 
         logger.info(f"Worker for strain_idx {strain_idx}: Finished writing {total_written_count} k-mers to {temp_file_path}")
         logger.info(f"Worker finished for {task}")


### PR DESCRIPTION
This commit modifies the k-mer database construction pipeline to use uncompressed plain text files for intermediate data storage during the map, concatenate, and sort phases. This change prioritizes processing speed over disk space for these temporary files, based on your feedback.

Key changes:

1.  **Processing Output:**
    - I now write k-mer data to `.part.txt` files instead of `.part.gz`.
    - File I/O is now done using `open()` in text mode instead of `gzip.open()` in binary mode.

2.  **Concatenation:**
    - In `_build_kmer_database_parallel`, the script now looks for `.part.txt` files.
    - The concatenation of these part files is now performed using `cat` instead of `zcat`. Robust command construction using `shlex.quote` and `find/xargs` for many files is implemented.

3.  **Sorting:**
    - The external `sort` command no longer uses the `--compress-program=gzip` flag. Both the input (`all_parts_file`) and output (`sorted_parts_file`) of the sort command are now uncompressed plain text.

4.  **Reduce Phase:**
    - Confirmed that the Reduce phase correctly reads the uncompressed `sorted_parts_file` without changes to its file opening logic.

5.  **External Commands:**
    - The `check_external_commands` list has been updated to reflect the use of `cat`, `find`, and `xargs`, and implicitly the non-use of `zcat` for this stage.

These changes are intended to reduce CPU overhead from compression/ decompression during the intermediate file processing steps, potentially speeding up the overall database build process, especially the initial k-mer dumping and the sort phase.