### PR TITLE
Clean up unused code in build_db.py and address test issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,17 +3,22 @@ name = "strainr"
 version = "0.1.0"
 description = ""
 authors = ["mladen5000 <mladen.rasic@gmail.com>"]
-packages = [{include = "strainr", from = "src"}]
+packages = [{include = "strainr"}]
 
 
 [tool.poetry.dependencies]
 python = ">3.10,<=3.14"
 numpy = "^2.2.6"
 scipy = "^1.15.3"
-# pandas = "~2.2.0" # Commented out again
+pandas = "~2.2.0"
+pyarrow = "^17.0.0" # Added pyarrow
+mmh3 = "^4.1.0" # Added mmh3
+typer = {extras = ["all"], version = "^0.12.3"} # Added typer
+pydantic = "^2.0.0" # Added pydantic
 tqdm = "^4.67.1"
 biopython = "^1.85"
 ncbi-genome-download = "^0.3.3"
+kmer-counter-rs = {path = "/app/kmer_counter_rs/target/wheels/kmer_counter_rs-0.1.0-cp312-cp312-linux_x86_64.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0" # Ensuring pytest is a dev dependency
@@ -24,14 +29,11 @@ build-backend = "maturin"
 
 # PROJECT_ROOT/pyproject.toml
 [tool.pytest.ini_options]
-pythonpath = [
-  "src",
-]
 # Add other pytest configurations if needed, e.g., testpaths
 testpaths = [
     "tests"
 ]
 
 [tool.maturin]
-python-source = "strainr"
+manifest-path = "kmer_counter_rs/Cargo.toml"
 module-name = "kmer_counter_rs"

--- a/strainr/classify.py
+++ b/strainr/classify.py
@@ -212,6 +212,8 @@ class SequenceFileProcessor:
         )
         if not isinstance(fwd_id, str):
             fwd_id = str(fwd_id)
+        # Normalize read ID
+        fwd_id = fwd_id.split(' ')[0].split('/')[0]
         fwd_seq_str = (
             str(getattr(fwd_record, "seq", ""))
             if hasattr(fwd_record, "seq")
@@ -241,7 +243,8 @@ class SequenceFileProcessor:
                     f"Reverse file ended before forward file at read {fwd_id}. Treating remaining as single-end."
                 )
                 rev_iter = None
-        yield fwd_id, fwd_seq_bytes, rev_seq_bytes
+        if fwd_seq_bytes: # Only yield if forward sequence is not empty
+            yield fwd_id, fwd_seq_bytes, rev_seq_bytes
 
     @staticmethod
     def parse_sequence_files(

--- a/strainr/database.py
+++ b/strainr/database.py
@@ -253,17 +253,13 @@ class StrainKmerDatabase:  # Renamed from StrainKmerDb
         kmer_strain_df: pd.DataFrame,
         count_matrix: np.ndarray,
         kmer_type_is_str: bool,
+        current_k_len: int,
     ) -> None:
         """Populates the self.kmer_to_counts_map from the DataFrame and count matrix."""
         self.kmer_to_counts_map.clear()  # Ensure it's empty before populating
         skipped_kmers_count = 0
 
-        # self.kmer_length should be set (either from metadata, expected_kmer_length, or inferred)
-        # and validated by _infer_and_set_kmer_length before this method is called.
-        if self.kmer_length is None:
-            raise RuntimeError("K-mer length was not set before calling _populate_kmer_map.")
-
-        current_k_len = self.kmer_length # Should be an int now
+        # current_k_len is now passed directly
 
         for i, kmer_obj in enumerate(kmer_strain_df.index):
             # Validate type and encode if needed
@@ -293,7 +289,7 @@ class StrainKmerDatabase:  # Renamed from StrainKmerDb
                 kmer_bytes = kmer_obj
 
             # Validate length
-            if len(kmer_bytes) != current_k_len:
+            if len(kmer_bytes) != current_k_len: # Ensure this uses the passed current_k_len
                 logger.warning(
                     f"K-mer '{kmer_obj}' (index {i}) has inconsistent length: {len(kmer_bytes)}. Expected {current_k_len}. Skipping."
                 )

--- a/test_rust_build.py
+++ b/test_rust_build.py
@@ -35,34 +35,15 @@ def test_kmer_extraction():
         return False
 
 
-def test_fallback():
-    """Test Python fallback works when Rust is not available."""
-    # Simulate missing Rust module
-    import sys
-
-    if "kmer_counter_rs" in sys.modules:
-        del sys.modules["kmer_counter_rs"]
-
-    # Test Python implementation from build_db.py
-    from strainr.build_db import DatabaseBuilder
-
-    builder = DatabaseBuilder(type("Args", (), {"skip_n_kmers": False, "kmerlen": 3})())
-
-    test_seq = b"ATCGATCG"
-    kmers = builder._extract_kmers_from_bytes(test_seq, 3)
-    print(f"✓ Python fallback extracted {len(kmers)} k-mers")
-    return True
-
-
 if __name__ == "__main__":
     print("Testing Rust k-mer extraction module...")
 
     rust_works = test_rust_import()
     if rust_works:
         test_kmer_extraction()
-    else:
-        print("Testing Python fallback...")
-        test_fallback()
+    # else: # Fallback logic removed
+        # print("Testing Python fallback...")
+        # test_fallback()
 
     print("\nTo build the Rust module, run:")
     print("  cd kmer_counter_rs")

--- a/tests/test_build_db.py
+++ b/tests/test_build_db.py
@@ -114,110 +114,6 @@ GCA_001,101,100,non_existent_GCA_001.fna.gz
         )
     assert len(filtered_files) == 0 # Since the file doesn't exist, it shouldn't be in the list
 
-
-@patch("strainr.build_db.open_file_transparently", new_callable=mock_open)
-def test_process_single_fasta_for_kmers_writes_correct_kmers(mock_actual_open, db_builder):
-    builder, test_dir, args_instance = db_builder
-    # Sequence: ATGCGTAGCATGC (13 bases)
-    # Kmerlen from fixture: args_instance.kmerlen (which is 5)
-    # Expected kmers (len 5):
-    # ATGCG, TGCGT, GCGTA, CGTAG, GTAGC, TAGCA, AGCAT, GCATG, CATGC
-    # Total: 13 - 5 + 1 = 9 kmers
-    mock_actual_open.return_value = StringIO(">seq1\nATGCGTAGCATGC\n")
-    dummy_fasta_path = test_dir / "dummy.fna.gz" # Not actually read due to mock_open
-    strain_name = "test_strain"
-    strain_idx = 0
-    # temp_kmer_file_path should be inside test_dir (which is tmp_path)
-    temp_kmer_file_path = test_dir / "kmer_output.txt"
-
-    genome_file_info = (dummy_fasta_path, strain_name, strain_idx, temp_kmer_file_path)
-
-    # Call the method. builder.args.kmerlen is already set by fixture.
-    # builder.args.skip_n_kmers is False by default in fixture.
-    # num_total_strains is optional, pass if it affects return type or logic for this test.
-    # The test expects (strain_name, written_kmer_count, output_path)
-    _, written_kmer_count, out_path = builder._process_single_fasta_for_kmers(
-        genome_file_info,
-        kmer_length=args_instance.kmerlen, # Use kmerlen from fixture's args
-        skip_n_kmers=args_instance.skip_n_kmers,
-        # num_total_strains=None # Let it use default to get the 3-tuple return
-    )
-    assert written_kmer_count == 9
-    assert out_path == temp_kmer_file_path
-
-    written_kmers = set()
-    # mock_open was used for open_file_transparently, not for reading the output file.
-    # So, we need to ensure the actual file was written to by the logic inside _process_single_fasta_for_kmers
-    # The current mock setup for open_file_transparently means the file reading part is mocked.
-    # The kmer generation is from the string directly.
-    # The writing part uses a standard open() call, so we need to check that.
-    # This test is for when output_path is provided.
-
-    # We need to check the *content* of temp_kmer_file_path
-    # The mock_open for open_file_transparently doesn't affect the open() used to write to output_path
-    # So, the file should have been written.
-
-    with open(temp_kmer_file_path, "r", encoding="utf-8") as f:
-        for line in f:
-            written_kmers.add(line.strip())
-
-    expected_kmers_str = {
-        "ATGCG", "TGCGT", "GCGTA", "CGTAG", "GTAGC",
-        "TAGCA", "AGCAT", "GCATG", "CATGC"
-    }
-    assert written_kmers == expected_kmers_str
-    if temp_kmer_file_path.exists():
-        temp_kmer_file_path.unlink()
-
-
-@patch("strainr.build_db.open_file_transparently", new_callable=mock_open)
-def test_process_single_fasta_kmers_seq_shorter_than_kmerlen(mock_actual_open, db_builder):
-    builder, test_dir, args_instance = db_builder
-    # Kmerlen from fixture: args_instance.kmerlen (which is 5)
-    # Sequence: ATG (3 bases) < 5
-    mock_actual_open.return_value = StringIO(">seq1\nATG\n")
-    dummy_fasta_path = test_dir / "short.fna.gz"
-    temp_kmer_file_path = test_dir / "short_kmer_output.txt"
-    genome_file_info = (dummy_fasta_path, "short_strain", 0, temp_kmer_file_path)
-
-    # Call with num_total_strains to get the 4-tuple return if that's what the original test structure implied
-    # Or None to get 3-tuple: (strain_name, written_kmer_count, output_path)
-    _, _, written_kmer_count, _ = builder._process_single_fasta_for_kmers(
-        genome_file_info,
-        kmer_length=args_instance.kmerlen,
-        skip_n_kmers=args_instance.skip_n_kmers,
-        num_total_strains=1 # Ensure 4-tuple return for consistency if previous test structure relied on it
-    )
-    assert written_kmer_count == 0
-    assert temp_kmer_file_path.exists() # File should be created even if empty
-    with open(temp_kmer_file_path, "r") as f:
-        assert f.read() == ""
-    if temp_kmer_file_path.exists():
-        temp_kmer_file_path.unlink()
-
-
-@patch("strainr.build_db.open_file_transparently", new_callable=mock_open)
-def test_process_single_fasta_kmers_seq_equals_kmerlen(mock_actual_open, db_builder):
-    builder, test_dir, args_instance = db_builder
-    # Kmerlen from fixture: args_instance.kmerlen (which is 5)
-    # Sequence: ATGCG (5 bases) == 5. Should yield 1 kmer.
-    mock_actual_open.return_value = StringIO(">seq1\nATGCG\n")
-    dummy_fasta_path = test_dir / "equal.fna.gz"
-    temp_kmer_file_path = test_dir / "equal_kmer_output.txt"
-    genome_file_info = (dummy_fasta_path, "equal_strain", 0, temp_kmer_file_path)
-
-    _, _, written_kmer_count, _ = builder._process_single_fasta_for_kmers(
-        genome_file_info,
-        kmer_length=args_instance.kmerlen,
-        skip_n_kmers=args_instance.skip_n_kmers,
-        num_total_strains=1
-    )
-    assert written_kmer_count == 1
-    with open(temp_kmer_file_path, "r") as f:
-        assert f.read().strip() == "ATGCG"
-    if temp_kmer_file_path.exists():
-        temp_kmer_file_path.unlink()
-
 # --- Tests for BuildDBArgs Pydantic Model ---
 
 def test_builddbargs_valid_taxid():
@@ -366,13 +262,21 @@ def test_build_kmer_database_parallel_writes_metadata(
 
     # Mock glob to return a list of dummy part files
     # Example: tmp_path / "test_db_metadata_build_files" / "tmp_kmer_parts" / "*.part.gz"
-    mock_glob.return_value = [temp_kmer_parts_dir / "0.part.gz"]
+    mock_glob.return_value = [temp_kmer_parts_dir / "0.part.txt"] # Ensure .txt extension
 
     # Mock subprocess.run to simulate success for sort and zcat
     mock_subprocess_run.return_value = MagicMock(returncode=0, stderr="")
 
     # Mock the worker function to avoid actual k-mer processing
-    mock_process_worker.return_value = temp_kmer_parts_dir / "0.part.gz" # Simulate worker creates a file
+    def mock_worker_side_effect(task_tuple):
+        genome_file, strain_name, strain_idx, kmer_length, skip_n_kmers, temp_dir_arg = task_tuple
+        output_file = temp_dir_arg / f"{strain_idx}.part.txt"
+        # Ensure the temp_dir_arg (which is temp_kmer_parts_dir inside the test) exists
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(f"dummy_kmer_for_{strain_idx}\t{strain_idx}\n") # Write some content
+        return output_file
+
+    mock_process_worker.side_effect = mock_worker_side_effect
 
     # Mock open for the sorted file reading part
     # Simulate a very simple sorted k-mer file content: kmer_hex\tstrain_idx
@@ -415,95 +319,6 @@ def test_build_kmer_database_parallel_writes_metadata(
 
     assert b"strainr_skip_n_kmers" in schema.metadata
     assert schema.metadata[b"strainr_skip_n_kmers"] == str(skip_n_val).encode('utf-8')
-
-
-def test_rust_kmer_counter_usage_and_correctness(tmp_path: pathlib.Path):
-    """
-    Tests if the Rust k-mer counter is used when available and if its output
-    is consistent with the Python k-mer extraction logic.
-    """
-    import strainr.build_db # For accessing module-level flags
-    from strainr.build_db import DatabaseBuilder, BuildDBArgs
-    from kmer_counter_rs import extract_kmers_rs as rust_extract_func
-
-    # Args for DatabaseBuilder
-    args = BuildDBArgs(
-        custom=tmp_path, # Needs a valid path
-        kmerlen=5,
-        skip_n_kmers=False # Test with skip_n_kmers=False first
-    )
-    db_builder_instance = DatabaseBuilder(args=args)
-
-    # 1. Check if Rust module is active
-    assert strainr.build_db._RUST_KMER_COUNTER_AVAILABLE is True, "Rust k-mer counter should be available."
-    assert strainr.build_db._extract_kmers_func == rust_extract_func, "DatabaseBuilder should be configured to use Rust k-mer extraction."
-
-    # 2. Define sample sequence and k-mer length
-    sample_sequence_str = "ATGCGTAGCATGCGT"
-    sample_sequence_bytes = sample_sequence_str.encode('utf-8')
-    kmer_len = 5
-
-    # 3. Call _extract_kmers_from_bytes (should use Rust)
-    # Ensure the builder's args are set for this specific test scenario if they affect kmer extraction
-    db_builder_instance.args.kmerlen = kmer_len
-    db_builder_instance.args.skip_n_kmers = False # Explicitly set for this part of the test
-
-    rust_kmers_list = db_builder_instance._extract_kmers_from_bytes(sample_sequence_bytes, kmer_len)
-    rust_kmers_set = set(rust_kmers_list) # Convert list of k-mers to set for comparison
-
-    # 4. Get expected k-mers using Python logic (DatabaseBuilder._py_extract_canonical_kmers_static)
-    # The _py_extract_canonical_kmers_static method returns a list of bytes.
-    py_kmers_list = DatabaseBuilder._py_extract_canonical_kmers_static(
-        sample_sequence_bytes, kmer_len, False # skip_n_kmers = False
-    )
-    py_kmers_set = set(py_kmers_list)
-
-    # 5. Assert sets are identical
-    assert rust_kmers_set == py_kmers_set, \
-        f"Rust k-mer set {rust_kmers_set} differs from Python k-mer set {py_kmers_set} (skip_n_kmers=False)"
-
-    # 6. Test with skip_n_kmers=True (and a sequence containing 'N')
-    db_builder_instance.args.skip_n_kmers = True
-    sample_sequence_n_str = "ATGCGNTNNCATGCGT"
-    sample_sequence_n_bytes = sample_sequence_n_str.encode('utf-8')
-
-    rust_kmers_n_list = db_builder_instance._extract_kmers_from_bytes(sample_sequence_n_bytes, kmer_len)
-    rust_kmers_n_set = set(rust_kmers_n_list)
-
-    py_kmers_n_list = DatabaseBuilder._py_extract_canonical_kmers_static(
-        sample_sequence_n_bytes, kmer_len, True # skip_n_kmers = True
-    )
-    py_kmers_n_set = set(py_kmers_n_list)
-
-    assert rust_kmers_n_set == py_kmers_n_set, \
-        f"Rust k-mer set {rust_kmers_n_set} differs from Python k-mer set {py_kmers_n_set} (skip_n_kmers=True)"
-
-    # Test case: what if Rust is NOT available (e.g. by temporarily overriding the flag)
-    # This part of the test ensures the fallback mechanism works as expected.
-    try:
-        original_rust_available = strainr.build_db._RUST_KMER_COUNTER_AVAILABLE
-        original_extract_func = strainr.build_db._extract_kmers_func
-
-        strainr.build_db._RUST_KMER_COUNTER_AVAILABLE = False
-        strainr.build_db._extract_kmers_func = None # Simulate Rust not being imported
-
-        # Re-create builder instance or ensure its state reflects the change
-        # For this test, simply changing the global flags should be enough as _extract_kmers_from_bytes checks them.
-
-        # With Rust disabled, it should use the Python path.
-        # We expect the result to be the same as py_kmers_set calculated earlier.
-        fallback_kmers_list = db_builder_instance._extract_kmers_from_bytes(sample_sequence_bytes, kmer_len)
-        fallback_kmers_set = set(fallback_kmers_list)
-
-        assert fallback_kmers_set == py_kmers_set, \
-            "Fallback to Python k-mer extraction did not produce the expected Python k-mers."
-        assert strainr.build_db._extract_kmers_func is None, \
-            "After disabling Rust, _extract_kmers_func should be None (Python path)."
-
-    finally:
-        # Restore original state
-        strainr.build_db._RUST_KMER_COUNTER_AVAILABLE = original_rust_available
-        strainr.build_db._extract_kmers_func = original_extract_func
 
 
 # --- Integration test for k-mer extraction pipeline consistency ---
@@ -585,7 +400,7 @@ GGNNAACCTTGGNACC
             if not output_part_file.exists(): # pragma: no cover
                 raise FileNotFoundError(f"Worker did not produce output file: {output_part_file}")
 
-            with gzip.open(output_part_file, "rt") as f_in:
+            with open(output_part_file, "rt", encoding='utf-8') as f_in: # Changed from gzip.open
                 for line in f_in:
                     kmer_hex = line.strip().split("\t")[0]
                     extracted_kmers.add(bytes.fromhex(kmer_hex))

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -3,8 +3,10 @@ Pytest unit tests for strainr.classify module.
 """
 import pytest
 import pathlib
+import numpy as np # Added numpy import
 from typing import List, Tuple, Generator
-from unittest.mock import patch, mock_open
+from collections import Counter # Added Counter import
+from unittest.mock import patch, mock_open, MagicMock
 
 from strainr.classify import SequenceFileProcessor, DEFAULT_CHUNK_SIZE
 from strainr.genomic_types import ReadId # Assuming ReadId is just str

--- a/tests/test_kmer_counter_rs.py
+++ b/tests/test_kmer_counter_rs.py
@@ -74,15 +74,16 @@ class TestExtractKmerRs(unittest.TestCase):
         temp_fasta = self._create_temp_fasta_file([("seq1", "AGCTTTCA")])
         try:
             result = extract_kmer_rs(temp_fasta, 4, False)
-            # AGCT -> AGCT
-            # GCTT -> AAGC (canonical)
-            # CTTT -> AAAG (canonical)
-            # TTTC -> AAAG (canonical)
-            # TTCA -> TGAA (canonical)
+            # AGCT (rc AGCT) -> AGCT
+            # GCTT (rc AAGC) -> AAGC
+            # CTTT (rc AAAG) -> AAAG
+            # TTTC (rc GAAA) -> GAAA
+            # TTCA (rc TGAA) -> TGAA
             expected = {
                 b"AGCT": 1,
                 b"AAGC": 1,
-                b"AAAG": 2, # CTTT and TTTC both map to AAAG
+                b"AAAG": 1,
+                b"GAAA": 1,
                 b"TGAA": 1,
             }
             self.assertEqual(result, expected)
@@ -202,11 +203,14 @@ class TestExtractKmerRs(unittest.TestCase):
             # ANNA (k=3):
             # ANN (rc NNT) -> ANN (A < N)
             # NNA (rc TNN). Canonical of NNA and ANN. ANN is smaller (A vs N).
-            #   NNA vs ANN. N vs A. ANN is smaller.
-            #   So, for "NNA", its canonical is "ANN".
+            #   NNA vs ANN. N vs A. ANN is smaller. -> This logic was flawed.
+            #   Correct:
+            #   ANN (rc NNT) -> canonical is ANN
+            #   NNA (rc TNN) -> canonical is NNA
             expected = {
                 b"ACG": 2,
-                b"ANN": 2,
+                b"ANN": 1,
+                b"NNA": 1,
             }
             self.assertEqual(result, expected)
         finally:

--- a/tests/test_strain_kmer_db.py
+++ b/tests/test_strain_kmer_db.py
@@ -229,7 +229,8 @@ def test_skdb_init_kmer_length_inferred(
     captured = capsys.readouterr()
     # The specific log message about inference is not present, the main check is db.kmer_length
     # Ensure the summary print contains the kmer length, e.g.
-    assert f"- K-mer length: {default_kmer_length_skdb}" in captured.out
+    # Updated to match the new log format which includes "(final)"
+    assert f"- K-mer length (final): {default_kmer_length_skdb}" in captured.out
 
 
 @pytest.mark.parametrize("parquet_skdb_path", [{"kmer_type": "str"}], indirect=True)


### PR DESCRIPTION
Removed several unused methods from strainr/build_db.py:
- _extract_kmers_from_bytes
- fast_kmers_numpy
- _py_reverse_complement_db
- _process_single_fasta_for_kmers
- _save_database_to_parquet
- _process_and_write_kmers (instance method)

Removed associated tests for these methods from test_rust_build.py and tests/test_build_db.py.

Iteratively corrected pyproject.toml to:
- Specify correct Python package path for 'strainr'.
- Add manifest-path for kmer_counter_rs to [tool.maturin].
- Add missing dependencies: pandas, pyarrow, mmh3, typer, pydantic.
- Resolved Rust extension import issues by building kmer_counter_rs as a wheel and adding it as a path dependency.

Addressed numerous test failures by:
- Adding missing imports (np, logging, Counter) in test files.
- Correcting method signatures and calls (e.g., _populate_kmer_map).
- Fixing incorrect file handling in tests (e.g., gzip.open vs open).
- Improving mocking logic for file creation.
- Updating assertion values and error messages based on code changes.

Work is ongoing to resolve all test failures. Current state reflects significant cleanup and dependency correction.